### PR TITLE
Feature: #48 정산 등록  및 정산 금액 배분 기능 구현

### DIFF
--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -1,9 +1,6 @@
 package com.zero.cohousesever.settlement.controller;
 
-import com.zero.cohousesever.settlement.dto.PaymentCompleteRequest;
-import com.zero.cohousesever.settlement.dto.PaymentHistoryResponse;
-import com.zero.cohousesever.settlement.dto.SettlementDto;
-import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
+import com.zero.cohousesever.settlement.dto.*;
 import com.zero.cohousesever.settlement.service.PaymentService;
 import com.zero.cohousesever.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
@@ -30,9 +27,11 @@ public class SettlementController {
 
     // 정산 등록
     @PostMapping
-    public ResponseEntity<SettlementDto> createSettlement() {
-
-        return ResponseEntity.ok().build();
+    public ResponseEntity<SettlementDto> createSettlement(@RequestBody CreateSettlementRequest request) {
+        //TODO JWT 사용자 ID로 결제자 선정
+        Long payerId = 2L;
+        SettlementDto settlementDto = settlementService.createSettlement(payerId, request);
+        return ResponseEntity.ok(settlementDto);
     }
 
     // 정산 상세 조회

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -2,6 +2,7 @@ package com.zero.cohousesever.settlement.controller;
 
 import com.zero.cohousesever.settlement.dto.PaymentCompleteRequest;
 import com.zero.cohousesever.settlement.dto.PaymentHistoryResponse;
+import com.zero.cohousesever.settlement.dto.SettlementDto;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
 import com.zero.cohousesever.settlement.service.PaymentService;
 import com.zero.cohousesever.settlement.service.SettlementService;
@@ -29,7 +30,7 @@ public class SettlementController {
 
     // 정산 등록
     @PostMapping
-    public ResponseEntity<?> createSettlement() {
+    public ResponseEntity<SettlementDto> createSettlement() {
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
@@ -4,6 +4,7 @@ import com.zero.cohousesever.settlement.entity.SettlementCategory;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 // 정산 요청 DTO
@@ -13,6 +14,6 @@ public class CreateSettlementRequest {
     private String title;
     private String description;
     private SettlementCategory category;
-    private Long settlementAmount;
+    private BigDecimal settlementAmount;
     private List<Long> participantIds;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/SettlementDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/SettlementDto.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.settlement.dto;
 
+import com.zero.cohousesever.settlement.entity.Settlement;
 import com.zero.cohousesever.settlement.entity.SettlementCategory;
 import com.zero.cohousesever.settlement.entity.SettlementStatus;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 // 정산 응답 DTO
 @Getter
@@ -26,4 +28,32 @@ public class SettlementDto {
     private List<ParticipantDto> participants;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static SettlementDto fromEntity(Settlement settlement) {
+        List<ParticipantDto> participantDtos = settlement.getParticipants().stream()
+                .map(participant -> new ParticipantDto(
+                        participant.getId(),
+                        participant.getMember().getId(),
+                        participant.getMember().getName(),
+                        participant.getShareAmount(),
+                        participant.getStatus(),
+                        participant.getPaidAt()
+                ))
+                .collect(Collectors.toList());
+
+        return new SettlementDto(
+                settlement.getId(),
+                settlement.getCategory(),
+                settlement.getTitle(),
+                settlement.getDescription(),
+                settlement.getSettlementAmount().longValue(),
+                settlement.getStatus(),
+                settlement.getImageUrl(),
+                settlement.getPayer().getId(),
+                settlement.getPayer().getName(),
+                participantDtos,
+                settlement.getCreatedAt(),
+                settlement.getUpdatedAt()
+        );
+    }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
@@ -35,7 +35,7 @@ public class Participant extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private PaymentStatus status = PaymentStatus.PENDING;
+    private PaymentStatus status;
 
     private LocalDateTime paidAt;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
@@ -8,9 +8,11 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @Table(name = "settlement_participants")
 public class Participant extends BaseEntity {
@@ -25,7 +27,7 @@ public class Participant extends BaseEntity {
 
     // 배분 금액
     @Column(name = "share_amount", nullable = false)
-    private BigDecimal shareAmount; // 배분 금액 소수점일 경우 고려하여 BigDecimal 사용
+    private BigDecimal shareAmount;
 
     // 실제 송금 금액
     @Column(name = "paid_amount")
@@ -34,4 +36,6 @@ public class Participant extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PaymentStatus status = PaymentStatus.PENDING;
+
+    private LocalDateTime paidAt;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/PaymentStatus.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/PaymentStatus.java
@@ -2,7 +2,7 @@ package com.zero.cohousesever.settlement.entity;
 
 public enum PaymentStatus {
     PENDING,     // 송금 대기 중 (아직 송금 미완료)
-    SENT,        // 송금 완료
+    PAID,        // 송금 완료
     REFUNDED,    // 환불됨 (송금 완료 후 환불된 경우)
     REFUND_FAILED, // 환불 시도 실패 (재시도 필요)
     CANCELED,    // 취소됨 (송금 전에 정산 자체가 취소된 경우)

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
@@ -3,16 +3,21 @@ package com.zero.cohousesever.settlement.entity;
 import com.zero.cohousesever.common.entity.BaseEntity;
 import com.zero.cohousesever.member.entity.Member;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@Setter
+@Getter
 @NoArgsConstructor
 @Table(name = "settlements")
 public class Settlement extends BaseEntity {
+    @Column(nullable = false)
     private String title;
     private String description;
 

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -19,7 +19,9 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +33,10 @@ public class SettlementService {
     /**
      * 정산 등록
      */
-    public SettlementDto createSettlement(CreateSettlementRequest request) {
+    public SettlementDto createSettlement(Long payerId, CreateSettlementRequest request) {
+        Member payer = memberRepository.findById(payerId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + payerId));
+
         Settlement settlement = new Settlement();
         settlement.setTitle(request.getTitle());
         settlement.setDescription(request.getDescription());
@@ -39,27 +44,37 @@ public class SettlementService {
 
         settlement.setSettlementAmount(request.getSettlementAmount());
         settlement.setStatus(SettlementStatus.PENDING);
+        settlement.setPayer(payer);
+
+        Set<Long> allParticipantIds = new HashSet<>(request.getParticipantIds());
+        allParticipantIds.add(payerId); // 결제자 ID도 포함시킴
 
         List<Participant> participants = new ArrayList<>();
-        for (Long memberId : request.getParticipantIds()) {
+        for (Long memberId : allParticipantIds) {
             Member member = memberRepository.findById(memberId)
                     .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
 
             Participant participant = new Participant();
             participant.setMember(member);
             participant.setSettlement(settlement);
-            participant.setStatus(PaymentStatus.PENDING);
-            participant.setShareAmount(calculateShareAmount(request.getSettlementAmount(), request.getParticipantIds().size()));
+
+            if(memberId.equals(payerId)) {
+                participant.setStatus(PaymentStatus.PAID); // 결제자: 송금 완료 상태
+            } else {
+                participant.setStatus(PaymentStatus.PENDING); // 참여자: 대기 상태
+            }
+
+            participant.setShareAmount(calculateShareAmount(request.getSettlementAmount(), allParticipantIds.size()));
             participants.add(participant);
         }
         settlement.setParticipants(participants);
-
         Settlement savedSettlement = settlementRepository.save(settlement);
         return SettlementDto.fromEntity(savedSettlement);
     }
 
     // 배분 금액 계산 함수
     public BigDecimal calculateShareAmount(BigDecimal totalAmount, int participantCount) {
+        //TODO 똑같이 분배되지 않는 경우에 대한 로직 필요
         if (participantCount <= 0) {
             throw new IllegalArgumentException("참여자 수는 1 이상이어야 합니다.");
         }

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -1,12 +1,24 @@
 package com.zero.cohousesever.settlement.service;
 
+import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.repository.MemberRepository;
+import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
+import com.zero.cohousesever.settlement.dto.SettlementDto;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
+import com.zero.cohousesever.settlement.entity.Participant;
+import com.zero.cohousesever.settlement.entity.PaymentStatus;
+import com.zero.cohousesever.settlement.entity.Settlement;
+import com.zero.cohousesever.settlement.entity.SettlementStatus;
 import com.zero.cohousesever.settlement.repository.ParticipantRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -14,19 +26,50 @@ import java.util.List;
 public class SettlementService {
     private final SettlementRepository settlementRepository;
     private final ParticipantRepository participantRepository;
+    private final MemberRepository memberRepository;
 
-    // TODO: 실제 서비스 로직 구현 예정
+    /**
+     * 정산 등록
+     */
+    public SettlementDto createSettlement(CreateSettlementRequest request) {
+        Settlement settlement = new Settlement();
+        settlement.setTitle(request.getTitle());
+        settlement.setDescription(request.getDescription());
+        settlement.setCategory(request.getCategory());
+
+        settlement.setSettlementAmount(request.getSettlementAmount());
+        settlement.setStatus(SettlementStatus.PENDING);
+
+        List<Participant> participants = new ArrayList<>();
+        for (Long memberId : request.getParticipantIds()) {
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
+
+            Participant participant = new Participant();
+            participant.setMember(member);
+            participant.setSettlement(settlement);
+            participant.setStatus(PaymentStatus.PENDING);
+            participant.setShareAmount(calculateShareAmount(request.getSettlementAmount(), request.getParticipantIds().size()));
+            participants.add(participant);
+        }
+        settlement.setParticipants(participants);
+
+        Settlement savedSettlement = settlementRepository.save(settlement);
+        return SettlementDto.fromEntity(savedSettlement);
+    }
+
+    // 배분 금액 계산 함수
+    public BigDecimal calculateShareAmount(BigDecimal totalAmount, int participantCount) {
+        if (participantCount <= 0) {
+            throw new IllegalArgumentException("참여자 수는 1 이상이어야 합니다.");
+        }
+        return totalAmount.divide(BigDecimal.valueOf(participantCount), 2, RoundingMode.HALF_UP);
+    }
 
     /**
      * 정산 목록 조회 (페이징 및 필터링 포함)
      */
     public void getSettlements() {
-    }
-
-    /**
-     * 신규 정산 등록
-     */
-    public void createSettlement() {
     }
 
     /**


### PR DESCRIPTION
## Changes
정산 등록 시 정산 참여자 그룹 생성 및 금액 균등 배분 기능 추가

---

## Description
- SettlementService에 신규 정산 등록(createSettlement) 메서드 구현
- CreateSettlementRequest를 받아 Settlement 및 Participant 엔티티를 생성하고 저장
- 참여자 수에 따라 전체 금액을 균등 분배하는 calculateShareAmount 메서드 추가
- 저장된 엔티티를 SettlementDto로 매핑하여 반환

---

## Context
- 사용자 요청에 따른 신규 정산 등록 기능 개발  
- 사용자가 정산을 등록할 때, 여러 참여자에게 비용을 공평하게 배분하는 핵심 기능 추가
- 결제자는 송금 완료(`PAID`) 상태, 기타 참여자는 대기(`PENDING`) 상태로 구분  

---

## Reason
- 정산 결제자를 정산 참여자에 등록 시 HashSet으로 중복 참여자 방지, 데이터 무결성 확보
- 결제자는 항상 참여자 명단에 포함하여 송금 완료 상태로 초기화 하여 처리 편의성 향상
---

## Work Done
- SettlementService#createSettlement 메서드 구현
- CalculateShareAmount 유틸리티 메서드 추가
- Entity와 DTO 간 변환 로직(fromEntity) 작성 및 연결

DTO 설명
- **CreateSettlementRequest**: 클라이언트가 정산 등록 시 입력하는 요청 데이터(제목, 설명, 카테고리, 총 금액, 참여자 ID 목록)를 담는 DTO
- **SettlementDto**: 정산 상세 정보와 참여자 리스트를 포함하여 클라이언트에 반환하는 응답용 DTO
- **SettlementHistoryResponse**: 정산 이력 조회용으로 사용되는 요약 정보 DTO
- **PaymentHistoryResponse**: 송금 관련 이력 정보를 클라이언트에 전달하는 응답 DTO
- **ParticipantDto**: 정산 참여자 개별 정보를 표현하는 DTO (ID, 이름, 배분 금액, 송금 상태 등)

---

## Test Plan
- Postman을 이용한 API 정상 응답 확인

---

## Notes
- 현재 배분은 균등 분배이며, 소수점에 따른 잔여금 처리 로직은 추후 작업 예정
- 정산 등록 시 이미지 등록 및 OCR 처리 추후 작업 예정

---

## Issue
Closes #48 