### PR TITLE
Feature: #52 정산 참여자 송금 완료 및 취소 기능 추가

### DIFF
--- a/src/main/java/com/zero/cohousesever/common/entity/BaseEntity.java
+++ b/src/main/java/com/zero/cohousesever/common/entity/BaseEntity.java
@@ -2,6 +2,7 @@ package com.zero.cohousesever.common.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
+++ b/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
@@ -29,6 +29,9 @@ public enum ErrorCode {
     SETTLEMENT_STATUS_INVALID(HttpStatus.BAD_REQUEST, "정산 상태가 유효하지 않습니다."),
     SETTLEMENT_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "정산 생성에 실패했습니다."),
     SETTLEMENT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "정산 삭제에 실패했습니다."),
+    INVALID_MANUAL_DISTRIBUTION(HttpStatus.BAD_REQUEST, "직접 분배 금액 정보가 올바르지 않습니다."),
+    EXCEED_TOTAL_AMOUNT(HttpStatus.BAD_REQUEST, "분배 금액 합이 총 정산 금액을 초과했습니다."),
+    INVALID_PARTICIPANT_COUNT(HttpStatus.BAD_REQUEST, "참여자 수는 1명 이상이어야 합니다."),
 
     // 정산 및 송금 히스토리 관련 오류
     PAYMENT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 송금 내역을 찾을 수 없습니다."),

--- a/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
+++ b/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
     EXCEED_TOTAL_AMOUNT(HttpStatus.BAD_REQUEST, "분배 금액 합이 총 정산 금액을 초과했습니다."),
     INVALID_PARTICIPANT_COUNT(HttpStatus.BAD_REQUEST, "참여자 수는 1명 이상이어야 합니다."),
 
+    // 송금 관련 오류
+    PAYMENT_TRANSFER_FAILED (HttpStatus.INTERNAL_SERVER_ERROR, "송금 처리에 실패했습니다."),
+
     // 정산 및 송금 히스토리 관련 오류
     PAYMENT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 송금 내역을 찾을 수 없습니다."),
     PAYMENT_HISTORY_ALREADY_REFUNDED(HttpStatus.BAD_REQUEST, "이미 환불 처리된 송금 내역입니다."),

--- a/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
+++ b/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
@@ -14,12 +14,28 @@ public enum ErrorCode {
     MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
 
     // 그룹 관련 오류
+    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원의 그룹을 찾을 수 없습니다."),
 
     // 할일 관련 오류
 
     // 게시물 관련 오류
 
     // 정산 관련 오류
+    SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정산 정보를 찾을 수 없습니다."),
+    SETTLEMENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 정산 내역입니다."),
+    INVALID_SETTLEMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 정산 금액입니다."),
+    SETTLEMENT_DATE_INVALID(HttpStatus.BAD_REQUEST, "유효하지 않은 정산 날짜입니다."),
+    SETTLEMENT_PERMISSION_DENIED(HttpStatus.FORBIDDEN, "정산 권한이 없습니다."),
+    SETTLEMENT_STATUS_INVALID(HttpStatus.BAD_REQUEST, "정산 상태가 유효하지 않습니다."),
+    SETTLEMENT_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "정산 생성에 실패했습니다."),
+    SETTLEMENT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "정산 삭제에 실패했습니다."),
+
+    // 정산 및 송금 히스토리 관련 오류
+    PAYMENT_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 송금 내역을 찾을 수 없습니다."),
+    PAYMENT_HISTORY_ALREADY_REFUNDED(HttpStatus.BAD_REQUEST, "이미 환불 처리된 송금 내역입니다."),
+    PAYMENT_HISTORY_REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "송금 내역 환불 처리에 실패했습니다."),
+    NOT_A_SETTLEMENT_PARTICIPANT(HttpStatus.FORBIDDEN, "정산 참여자가 아닙니다."),
+    NOT_THE_SETTLEMENT_PAYER(HttpStatus.FORBIDDEN, "정산 결제자가 아닙니다."),
 
     // 알림 관련 오류
 

--- a/src/main/java/com/zero/cohousesever/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/zero/cohousesever/group/repository/GroupMemberRepository.java
@@ -1,10 +1,13 @@
 package com.zero.cohousesever.group.repository;
 
 import com.zero.cohousesever.group.entity.GroupMember;
+import com.zero.cohousesever.group.enums.GroupMemberStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
-
+    Optional<GroupMember> findByMemberIdAndStatus(Long memberId, GroupMemberStatus status);
 }

--- a/src/main/java/com/zero/cohousesever/member/entity/Member.java
+++ b/src/main/java/com/zero/cohousesever/member/entity/Member.java
@@ -6,10 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/main/java/com/zero/cohousesever/post/service/PostService.java
+++ b/src/main/java/com/zero/cohousesever/post/service/PostService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -26,6 +26,15 @@ public class SettlementController {
         return ResponseEntity.ok(settlementResponseDto);
     }
 
+    // 정산 취소
+    @DeleteMapping("/{settlementId}")
+    public ResponseEntity<?> cancelSettlement(@PathVariable Long settlementId) {
+        //TODO JWT 회원 정보 받기
+        Long memberId = 2L;
+        settlementService.cancelSettlement(memberId, settlementId);
+        return ResponseEntity.ok().build();
+    }
+
     // 정산 목록 조회
     @GetMapping
     public ResponseEntity<?> getSettlements() {
@@ -36,13 +45,6 @@ public class SettlementController {
     // 정산 상세 조회
     @GetMapping("/{settlementId}")
     public ResponseEntity<?> getSettlement() {
-
-        return ResponseEntity.ok().build();
-    }
-
-    // 정산 취소
-    @DeleteMapping("/{settlementId}")
-    public ResponseEntity<?> cancelSettlement() {
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -1,11 +1,10 @@
 package com.zero.cohousesever.settlement.controller;
 
 import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
-import com.zero.cohousesever.settlement.dto.SettlementDto;
+import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
 import com.zero.cohousesever.settlement.service.PaymentService;
 import com.zero.cohousesever.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
-import org.apache.tomcat.util.net.openssl.ciphers.Authentication;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,11 +26,11 @@ public class SettlementController {
 
     // 정산 등록
     @PostMapping
-    public ResponseEntity<SettlementDto> createSettlement(@RequestBody CreateSettlementRequest request) {
+    public ResponseEntity<SettlementResponseDto> createSettlement(@RequestBody CreateSettlementRequest request) {
         //TODO JWT 사용자 ID로 결제자 선정
         Long payerId = 2L;
-        SettlementDto settlementDto = settlementService.createSettlement(payerId, request);
-        return ResponseEntity.ok(settlementDto);
+        SettlementResponseDto settlementResponseDto = settlementService.createSettlement(payerId, request);
+        return ResponseEntity.ok(settlementResponseDto);
     }
 
     // 정산 상세 조회

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -34,8 +34,7 @@ public class SettlementController {
     @DeleteMapping("/{settlementId}")
     public ResponseEntity<?> cancelSettlement(@AuthenticationPrincipal CustomUserDetails userDetails,
                                               @PathVariable Long settlementId) {
-//        Long memberId = userDetails.getId();
-        Long memberId = 2L;
+        Long memberId = userDetails.getId();
 
         settlementService.cancelSettlement(memberId, settlementId);
         return ResponseEntity.noContent().build();
@@ -87,8 +86,7 @@ public class SettlementController {
     @PostMapping("/{settlementId}/payment")
     public ResponseEntity<?> completePayment(@AuthenticationPrincipal CustomUserDetails userDetails,
                                              @PathVariable Long settlementId) throws AccessDeniedException {
-//        Long memberId = userDetails.getId();
-        Long memberId = 4L;
+        Long memberId = userDetails.getId();
 
         paymentService.processPayment(memberId, settlementId);
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -54,19 +54,20 @@ public class SettlementController {
         return ResponseEntity.ok().build();
     }
 
-    // 정산 참여자 추가
-    @PostMapping("/{settlementId}/participants")
-    public ResponseEntity<?> addParticipant() {
-
-        return ResponseEntity.ok().build();
-    }
-
-    // 정산 참여자 제거
-    @DeleteMapping("/{settlementId}/participants/{participantId}")
-    public ResponseEntity<?> removeParticipant() {
-
-        return ResponseEntity.ok().build();
-    }
+    // FIXME 프론트에서 한번에 MAP으로 데이터 넘겨주기에 필요없음
+//    // 정산 참여자 추가
+//    @PostMapping("/{settlementId}/participants")
+//    public ResponseEntity<?> addParticipant() {
+//
+//        return ResponseEntity.ok().build();
+//    }
+//
+//    // 정산 참여자 제거
+//    @DeleteMapping("/{settlementId}/participants/{participantId}")
+//    public ResponseEntity<?> removeParticipant() {
+//
+//        return ResponseEntity.ok().build();
+//    }
 
     // 영수증 이미지 업로드
     @PostMapping("/{settlementId}/image")

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -88,7 +88,7 @@ public class SettlementController {
     public ResponseEntity<?> completePayment(@AuthenticationPrincipal CustomUserDetails userDetails,
                                              @PathVariable Long settlementId) throws AccessDeniedException {
 //        Long memberId = userDetails.getId();
-        Long memberId = 3L;
+        Long memberId = 4L;
 
         paymentService.processPayment(memberId, settlementId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -6,6 +6,7 @@ import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
 import com.zero.cohousesever.settlement.service.PaymentService;
 import com.zero.cohousesever.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +28,7 @@ public class SettlementController {
         Long payerId = 2L;
 
         SettlementResponseDto settlementResponseDto = settlementService.createSettlement(payerId, request);
-        return ResponseEntity.ok(settlementResponseDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(settlementResponseDto);
     }
 
     // 정산 취소
@@ -38,7 +39,7 @@ public class SettlementController {
         Long memberId = 2L;
 
         settlementService.cancelSettlement(memberId, settlementId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     // 정산 목록 조회
@@ -91,6 +92,6 @@ public class SettlementController {
         Long memberId = 4L;
 
         paymentService.processPayment(memberId, settlementId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -24,9 +24,8 @@ public class SettlementController {
     @PostMapping
     public ResponseEntity<SettlementResponseDto> createSettlement(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                   @RequestBody CreateSettlementRequest request) {
-//        Long payerId = userDetails.getId();
-        Long payerId = 2L;
-
+        Long payerId = userDetails.getId();
+        System.out.println(payerId);
         SettlementResponseDto settlementResponseDto = settlementService.createSettlement(payerId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(settlementResponseDto);
     }

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -1,11 +1,13 @@
 package com.zero.cohousesever.settlement.controller;
 
+import com.zero.cohousesever.member.security.CustomUserDetails;
 import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
 import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
 import com.zero.cohousesever.settlement.service.PaymentService;
 import com.zero.cohousesever.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
@@ -17,40 +19,44 @@ public class SettlementController {
     private final SettlementService settlementService;
     private final PaymentService paymentService;
 
-     // 정산 등록
+    // 정산 등록
     @PostMapping
-    public ResponseEntity<SettlementResponseDto> createSettlement(@RequestBody CreateSettlementRequest request) {
-        //TODO JWT 사용자 ID로 결제자 선정
+    public ResponseEntity<SettlementResponseDto> createSettlement(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                  @RequestBody CreateSettlementRequest request) {
+//        Long payerId = userDetails.getId();
         Long payerId = 2L;
+
         SettlementResponseDto settlementResponseDto = settlementService.createSettlement(payerId, request);
         return ResponseEntity.ok(settlementResponseDto);
     }
 
     // 정산 취소
     @DeleteMapping("/{settlementId}")
-    public ResponseEntity<?> cancelSettlement(@PathVariable Long settlementId) {
-        //TODO JWT 회원 정보 받기
+    public ResponseEntity<?> cancelSettlement(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                              @PathVariable Long settlementId) {
+//        Long memberId = userDetails.getId();
         Long memberId = 2L;
+
         settlementService.cancelSettlement(memberId, settlementId);
         return ResponseEntity.ok().build();
     }
 
     // 정산 목록 조회
     @GetMapping
-    public ResponseEntity<?> getSettlements() {
-
+    public ResponseEntity<?> getSettlements(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok().build();
     }
 
     // 정산 상세 조회
     @GetMapping("/{settlementId}")
-    public ResponseEntity<?> getSettlement() {
+    public ResponseEntity<?> getSettlement(@AuthenticationPrincipal CustomUserDetails userDetails) {
 
         return ResponseEntity.ok().build();
     }
 
     // 정산 참여자 목록 조회
     @GetMapping("/{settlementId}/participants")
-    public ResponseEntity<?> getParticipants() {
+    public ResponseEntity<?> getParticipants(@AuthenticationPrincipal CustomUserDetails userDetails) {
 
         return ResponseEntity.ok().build();
     }
@@ -72,17 +78,16 @@ public class SettlementController {
 
     // 영수증 이미지 업로드
     @PostMapping("/{settlementId}/image")
-    public ResponseEntity<?> uploadReceiptImage() {
+    public ResponseEntity<?> uploadReceiptImage(@AuthenticationPrincipal CustomUserDetails userDetails) {
 
         return ResponseEntity.ok().build();
     }
 
     // 송금 완료 처리
     @PostMapping("/{settlementId}/payment")
-    public ResponseEntity<?> completePayment(
-            @PathVariable Long settlementId) throws AccessDeniedException {
-        //FIXME JWT에서 회원 ID 추출하여 사용
-        //Long memberId = userDetails.getId();
+    public ResponseEntity<?> completePayment(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                             @PathVariable Long settlementId) throws AccessDeniedException {
+//        Long memberId = userDetails.getId();
         Long memberId = 3L;
 
         paymentService.processPayment(memberId, settlementId);

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -1,9 +1,6 @@
 package com.zero.cohousesever.settlement.controller;
 
-import com.zero.cohousesever.settlement.dto.PaymentCompleteRequest;
-import com.zero.cohousesever.settlement.dto.PaymentHistoryResponse;
-import com.zero.cohousesever.settlement.dto.SettlementDto;
-import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
+import com.zero.cohousesever.settlement.dto.*;
 import com.zero.cohousesever.settlement.service.PaymentService;
 import com.zero.cohousesever.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
@@ -30,9 +27,11 @@ public class SettlementController {
 
     // 정산 등록
     @PostMapping
-    public ResponseEntity<SettlementDto> createSettlement() {
-
-        return ResponseEntity.ok().build();
+    public ResponseEntity<SettlementDto> createSettlement(@RequestBody CreateSettlementRequest request) {
+        //TODO JWT 사용자 ID로 결제자 선정
+        Long payerId = 2L;
+        SettlementDto settlementDto = settlementService.createSettlement(payerId, request);
+        return ResponseEntity.ok(settlementDto);
     }
 
     // 정산 상세 조회

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -1,15 +1,15 @@
 package com.zero.cohousesever.settlement.controller;
 
-import com.zero.cohousesever.settlement.dto.*;
+import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
+import com.zero.cohousesever.settlement.dto.SettlementDto;
 import com.zero.cohousesever.settlement.service.PaymentService;
 import com.zero.cohousesever.settlement.service.SettlementService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
+import org.apache.tomcat.util.net.openssl.ciphers.Authentication;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
-import java.util.List;
+import java.nio.file.AccessDeniedException;
 
 @RestController
 @RequiredArgsConstructor
@@ -79,9 +79,12 @@ public class SettlementController {
     // 송금 완료 처리
     @PostMapping("/{settlementId}/payment")
     public ResponseEntity<?> completePayment(
-            @PathVariable Long settlementId,
-            @RequestBody PaymentCompleteRequest request) {
+            @PathVariable Long settlementId) throws AccessDeniedException {
+        //FIXME JWT에서 회원 ID 추출하여 사용
+        //Long memberId = userDetails.getId();
+        Long memberId = 3L;
 
+        paymentService.processPayment(memberId, settlementId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -2,6 +2,7 @@ package com.zero.cohousesever.settlement.controller;
 
 import com.zero.cohousesever.settlement.dto.PaymentCompleteRequest;
 import com.zero.cohousesever.settlement.dto.PaymentHistoryResponse;
+import com.zero.cohousesever.settlement.dto.SettlementDto;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
 import com.zero.cohousesever.settlement.service.PaymentService;
 import com.zero.cohousesever.settlement.service.SettlementService;
@@ -29,7 +30,7 @@ public class SettlementController {
 
     // 정산 등록
     @PostMapping
-    public ResponseEntity<?> createSettlement() {
+    public ResponseEntity<SettlementDto> createSettlement() {
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
+++ b/src/main/java/com/zero/cohousesever/settlement/controller/SettlementController.java
@@ -17,20 +17,20 @@ public class SettlementController {
     private final SettlementService settlementService;
     private final PaymentService paymentService;
 
-    // 정산 목록 조회
-    @GetMapping
-    public ResponseEntity<?> getSettlements() {
-
-        return ResponseEntity.ok().build();
-    }
-
-    // 정산 등록
+     // 정산 등록
     @PostMapping
     public ResponseEntity<SettlementResponseDto> createSettlement(@RequestBody CreateSettlementRequest request) {
         //TODO JWT 사용자 ID로 결제자 선정
         Long payerId = 2L;
         SettlementResponseDto settlementResponseDto = settlementService.createSettlement(payerId, request);
         return ResponseEntity.ok(settlementResponseDto);
+    }
+
+    // 정산 목록 조회
+    @GetMapping
+    public ResponseEntity<?> getSettlements() {
+
+        return ResponseEntity.ok().build();
     }
 
     // 정산 상세 조회

--- a/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
@@ -4,7 +4,6 @@ import com.zero.cohousesever.settlement.entity.SettlementCategory;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
 import java.util.List;
 
 // 정산 요청 DTO
@@ -14,6 +13,8 @@ public class CreateSettlementRequest {
     private String title;
     private String description;
     private SettlementCategory category;
-    private BigDecimal settlementAmount;
+    private boolean isEqualDistribution;
+    private Long settlementAmount;
+    private Long manualSharedAmount;
     private List<Long> participantIds;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
@@ -4,6 +4,7 @@ import com.zero.cohousesever.settlement.entity.SettlementCategory;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 // 정산 요청 DTO
@@ -13,6 +14,6 @@ public class CreateSettlementRequest {
     private String title;
     private String description;
     private SettlementCategory category;
-    private Long settlementAmount;
+    private BigDecimal settlementAmount;
     private List<Long> participantIds;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
@@ -1,15 +1,18 @@
 package com.zero.cohousesever.settlement.dto;
 
 import com.zero.cohousesever.settlement.entity.SettlementCategory;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 import java.util.Map;
 
 // 정산 요청 DTO
 @Getter
-@NoArgsConstructor
+@Setter
+@Builder
 public class CreateSettlementRequest {
     private String title;
     private String description;

--- a/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/CreateSettlementRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 // 정산 요청 DTO
 @Getter
@@ -13,8 +14,8 @@ public class CreateSettlementRequest {
     private String title;
     private String description;
     private SettlementCategory category;
-    private boolean isEqualDistribution;
+    private boolean equalDistribution;
     private Long settlementAmount;
-    private Long manualSharedAmount;
+    private Map<Long, Long> manualShares; // 참여자 ID별 직접 분배 금액
     private List<Long> participantIds;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/ParticipantDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/ParticipantDto.java
@@ -5,9 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-
 // 정산 참여자 DTO
 @Getter
 @NoArgsConstructor
@@ -16,7 +13,6 @@ public class ParticipantDto {
     private Long id;
     private Long memberId;
     private String memberName;
-    private BigDecimal shareAmount;
+    private Long shareAmount;
     private PaymentStatus status;
-    private LocalDateTime paidAt;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/ParticipantDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/ParticipantDto.java
@@ -1,6 +1,7 @@
 package com.zero.cohousesever.settlement.dto;
 
 import com.zero.cohousesever.settlement.entity.PaymentStatus;
+import com.zero.cohousesever.settlement.entity.SettlementParticipant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,4 +16,14 @@ public class ParticipantDto {
     private String memberName;
     private Long shareAmount;
     private PaymentStatus status;
+
+    public static ParticipantDto fromEntity(SettlementParticipant participant) {
+        return new ParticipantDto(
+                participant.getId(),
+                participant.getMember().getId(),
+                participant.getMember().getName(),
+                participant.getShareAmount(),
+                participant.getStatus()
+        );
+    }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/PaymentCompleteRequest.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/PaymentCompleteRequest.java
@@ -4,15 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PaymentCompleteRequest {
     private Long participantId;
-    private BigDecimal paidAmount;
-    private LocalDateTime paidAt;
-    private String note;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/SettlementDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/SettlementDto.java
@@ -36,8 +36,7 @@ public class SettlementDto {
                         participant.getMember().getId(),
                         participant.getMember().getName(),
                         participant.getShareAmount(),
-                        participant.getStatus(),
-                        participant.getPaidAt()
+                        participant.getStatus()
                 ))
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/zero/cohousesever/settlement/dto/SettlementDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/SettlementDto.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.settlement.dto;
 
+import com.zero.cohousesever.settlement.entity.Settlement;
 import com.zero.cohousesever.settlement.entity.SettlementCategory;
 import com.zero.cohousesever.settlement.entity.SettlementStatus;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 // 정산 응답 DTO
 @Getter
@@ -26,4 +28,32 @@ public class SettlementDto {
     private List<ParticipantDto> participants;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static SettlementDto fromEntity(Settlement settlement) {
+        List<ParticipantDto> participantDtos = settlement.getParticipants().stream()
+                .map(participant -> new ParticipantDto(
+                        participant.getId(),
+                        participant.getMember().getId(),
+                        participant.getMember().getName(),
+                        participant.getShareAmount(),
+                        participant.getStatus(),
+                        participant.getPaidAt()
+                ))
+                .collect(Collectors.toList());
+
+        return new SettlementDto(
+                settlement.getId(),
+                settlement.getCategory(),
+                settlement.getTitle(),
+                settlement.getDescription(),
+                settlement.getSettlementAmount().longValue(),
+                settlement.getStatus(),
+                settlement.getImageUrl(),
+                settlement.getPayer().getId(),
+                settlement.getPayer().getName(),
+                participantDtos,
+                settlement.getCreatedAt(),
+                settlement.getUpdatedAt()
+        );
+    }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/dto/SettlementResponseDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/SettlementResponseDto.java
@@ -15,21 +15,22 @@ import java.util.stream.Collectors;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class SettlementDto {
+public class SettlementResponseDto {
     private Long id;
     private SettlementCategory category;
     private String title;
     private String description;
-    private Long totalAmount;
+    private Long settlementAmount;
     private SettlementStatus status;
     private String imageUrl;
     private Long payerId;
     private String payerName;
+    private Long platformSupportAmount;
     private List<ParticipantDto> participants;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
-    public static SettlementDto fromEntity(Settlement settlement) {
+    public static SettlementResponseDto fromEntity(Settlement settlement) {
         List<ParticipantDto> participantDtos = settlement.getParticipants().stream()
                 .map(participant -> new ParticipantDto(
                         participant.getId(),
@@ -40,7 +41,7 @@ public class SettlementDto {
                 ))
                 .collect(Collectors.toList());
 
-        return new SettlementDto(
+        return new SettlementResponseDto(
                 settlement.getId(),
                 settlement.getCategory(),
                 settlement.getTitle(),
@@ -50,6 +51,7 @@ public class SettlementDto {
                 settlement.getImageUrl(),
                 settlement.getPayer().getId(),
                 settlement.getPayer().getName(),
+                settlement.getPlatformSupportAmount(),
                 participantDtos,
                 settlement.getCreatedAt(),
                 settlement.getUpdatedAt()

--- a/src/main/java/com/zero/cohousesever/settlement/dto/SettlementResponseDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/SettlementResponseDto.java
@@ -26,6 +26,7 @@ public class SettlementResponseDto {
     private Long payerId;
     private String payerName;
     private Long platformSupportAmount;
+    private boolean equalDistribution;
     private List<ParticipantDto> participants;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -46,6 +47,7 @@ public class SettlementResponseDto {
                 settlement.getPayer().getId(),
                 settlement.getPayer().getName(),
                 settlement.getPlatformSupportAmount(),
+                settlement.isEqualDistribution(),
                 participantDtos,
                 settlement.getCreatedAt(),
                 settlement.getUpdatedAt()

--- a/src/main/java/com/zero/cohousesever/settlement/dto/SettlementResponseDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/SettlementResponseDto.java
@@ -31,7 +31,7 @@ public class SettlementResponseDto {
     private LocalDateTime updatedAt;
 
     public static SettlementResponseDto fromEntity(Settlement settlement) {
-        List<ParticipantDto> participantDtos = settlement.getParticipants().stream()
+        List<ParticipantDto> participantDtos = settlement.getSettlementParticipants().stream()
                 .map(participant -> new ParticipantDto(
                         participant.getId(),
                         participant.getMember().getId(),

--- a/src/main/java/com/zero/cohousesever/settlement/dto/SettlementResponseDto.java
+++ b/src/main/java/com/zero/cohousesever/settlement/dto/SettlementResponseDto.java
@@ -32,13 +32,7 @@ public class SettlementResponseDto {
 
     public static SettlementResponseDto fromEntity(Settlement settlement) {
         List<ParticipantDto> participantDtos = settlement.getSettlementParticipants().stream()
-                .map(participant -> new ParticipantDto(
-                        participant.getId(),
-                        participant.getMember().getId(),
-                        participant.getMember().getName(),
-                        participant.getShareAmount(),
-                        participant.getStatus()
-                ))
+                .map(ParticipantDto::fromEntity)
                 .collect(Collectors.toList());
 
         return new SettlementResponseDto(
@@ -46,7 +40,7 @@ public class SettlementResponseDto {
                 settlement.getCategory(),
                 settlement.getTitle(),
                 settlement.getDescription(),
-                settlement.getSettlementAmount().longValue(),
+                settlement.getSettlementAmount(),
                 settlement.getStatus(),
                 settlement.getImageUrl(),
                 settlement.getPayer().getId(),

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
@@ -35,7 +35,7 @@ public class Participant extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private PaymentStatus status = PaymentStatus.PENDING;
+    private PaymentStatus status;
 
     private LocalDateTime paidAt;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
@@ -3,13 +3,13 @@ package com.zero.cohousesever.settlement.entity;
 import com.zero.cohousesever.common.entity.BaseEntity;
 import com.zero.cohousesever.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "settlement_participants")
 public class Participant extends BaseEntity {

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
@@ -7,9 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-
 @Entity
 @Getter
 @Setter
@@ -27,15 +24,15 @@ public class Participant extends BaseEntity {
 
     // 배분 금액
     @Column(name = "share_amount", nullable = false)
-    private BigDecimal shareAmount;
-
-    // 실제 송금 금액
-    @Column(name = "paid_amount")
-    private BigDecimal paidAmount;
+    private Long shareAmount;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PaymentStatus status;
 
-    private LocalDateTime paidAt;
+//    // 실제 송금 금액
+//    @Column(name = "paid_amount")
+//    private Long paidAmount;
+//
+//    private LocalDateTime paidAt;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Participant.java
@@ -8,9 +8,11 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @Table(name = "settlement_participants")
 public class Participant extends BaseEntity {
@@ -25,7 +27,7 @@ public class Participant extends BaseEntity {
 
     // 배분 금액
     @Column(name = "share_amount", nullable = false)
-    private BigDecimal shareAmount; // 배분 금액 소수점일 경우 고려하여 BigDecimal 사용
+    private BigDecimal shareAmount;
 
     // 실제 송금 금액
     @Column(name = "paid_amount")
@@ -34,4 +36,6 @@ public class Participant extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PaymentStatus status = PaymentStatus.PENDING;
+
+    private LocalDateTime paidAt;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/PaymentHistory.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/PaymentHistory.java
@@ -2,20 +2,20 @@ package com.zero.cohousesever.settlement.entity;
 
 import com.zero.cohousesever.common.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 /**
  * 송금 히스토리
  */
-@Entity
 @Table(name = "payment_histories")
 @Getter
 @Setter
+@Entity
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class PaymentHistory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "settlement_id", nullable = false)
@@ -36,15 +36,4 @@ public class PaymentHistory extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private PaymentStatus status;
-
-    public static PaymentHistory fromParticipants(Settlement settlement, Participant sender, Participant receiver, Long amount) {
-        PaymentHistory paymentHistory = new PaymentHistory();
-        paymentHistory.setSettlement(settlement);
-        paymentHistory.setSender(sender);
-        paymentHistory.setReceiver(receiver);
-        paymentHistory.setAmount(amount);
-        paymentHistory.setTransferDate(LocalDateTime.now());
-        paymentHistory.setStatus(PaymentStatus.PAID);
-        return paymentHistory;
-    }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/PaymentHistory.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/PaymentHistory.java
@@ -22,12 +22,12 @@ public class PaymentHistory extends BaseEntity {
     private Settlement settlement;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "payer_id", nullable = false)
-    private Participant payer; // 송금하는 정산 참여자
+    @JoinColumn(name = "sender_id", nullable = false)
+    private Participant sender; // 송금하는 정산 참여자
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "payee_id", nullable = false)
-    private Participant payee; // 송금 받는 정산 참여자
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private Participant receiver; // 송금 받는 정산 참여자
 
     private Long amount;             // 송금 금액
 
@@ -36,4 +36,15 @@ public class PaymentHistory extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private PaymentStatus status;
+
+    public static PaymentHistory fromParticipants(Settlement settlement, Participant sender, Participant receiver, Long amount) {
+        PaymentHistory paymentHistory = new PaymentHistory();
+        paymentHistory.setSettlement(settlement);
+        paymentHistory.setSender(sender);
+        paymentHistory.setReceiver(receiver);
+        paymentHistory.setAmount(amount);
+        paymentHistory.setTransferDate(LocalDateTime.now());
+        paymentHistory.setStatus(PaymentStatus.PAID);
+        return paymentHistory;
+    }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/PaymentHistory.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/PaymentHistory.java
@@ -1,6 +1,7 @@
 package com.zero.cohousesever.settlement.entity;
 
 import com.zero.cohousesever.common.entity.BaseEntity;
+import com.zero.cohousesever.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -23,11 +24,11 @@ public class PaymentHistory extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id", nullable = false)
-    private Participant sender; // 송금하는 정산 참여자
+    private Member sender; // 송금하는 정산 참여자
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)
-    private Participant receiver; // 송금 받는 정산 참여자
+    private Member receiver; // 송금 받는 정산 참여자
 
     private Long amount;             // 송금 금액
 

--- a/src/main/java/com/zero/cohousesever/settlement/entity/PaymentHistory.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/PaymentHistory.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.settlement.entity;
 
+import com.zero.cohousesever.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,21 +16,18 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
-public class PaymentHistory {
+public class PaymentHistory extends BaseEntity {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "settlement_id", nullable = false)
+    private Settlement settlement;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    // 송금하는 참여자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "payer_id", nullable = false)
-    private Participant payer;
+    private Participant payer; // 송금하는 정산 참여자
 
-    // 송금 받는 참여자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "payee_id", nullable = false)
-    private Participant payee;
+    private Participant payee; // 송금 받는 정산 참여자
 
     private Long amount;             // 송금 금액
 

--- a/src/main/java/com/zero/cohousesever/settlement/entity/PaymentStatus.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/PaymentStatus.java
@@ -2,7 +2,7 @@ package com.zero.cohousesever.settlement.entity;
 
 public enum PaymentStatus {
     PENDING,     // 송금 대기 중 (아직 송금 미완료)
-    SENT,        // 송금 완료
+    PAID,        // 송금 완료
     REFUNDED,    // 환불됨 (송금 완료 후 환불된 경우)
     REFUND_FAILED, // 환불 시도 실패 (재시도 필요)
     CANCELED,    // 취소됨 (송금 전에 정산 자체가 취소된 경우)

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
@@ -1,6 +1,7 @@
 package com.zero.cohousesever.settlement.entity;
 
 import com.zero.cohousesever.common.entity.BaseEntity;
+import com.zero.cohousesever.group.entity.Group;
 import com.zero.cohousesever.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -19,6 +20,10 @@ public class Settlement extends BaseEntity {
     @Column(nullable = false)
     private String title;
     private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
 
     @Enumerated(EnumType.STRING)
     private SettlementCategory category;
@@ -46,5 +51,5 @@ public class Settlement extends BaseEntity {
 
     // 정산 참여자 목록
     @OneToMany(mappedBy = "settlement", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<Participant> participants;
+    private List<SettlementParticipant> settlementParticipants;
 }

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
@@ -3,9 +3,7 @@ package com.zero.cohousesever.settlement.entity;
 import com.zero.cohousesever.common.entity.BaseEntity;
 import com.zero.cohousesever.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,6 +11,8 @@ import java.util.List;
 @Entity
 @Setter
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "settlements")
 public class Settlement extends BaseEntity {

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
@@ -3,16 +3,21 @@ package com.zero.cohousesever.settlement.entity;
 import com.zero.cohousesever.common.entity.BaseEntity;
 import com.zero.cohousesever.member.entity.Member;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@Setter
+@Getter
 @NoArgsConstructor
 @Table(name = "settlements")
 public class Settlement extends BaseEntity {
+    @Column(nullable = false)
     private String title;
     private String description;
 

--- a/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/Settlement.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -24,7 +23,14 @@ public class Settlement extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private SettlementCategory category;
 
-    private BigDecimal settlementAmount; // 정산 금액
+    @Column(nullable = false)
+    private boolean isEqualDistribution;  // true: 균등 분배, false: 개별 금액 분배
+
+    @Column(nullable = false)
+    private Long settlementAmount; // 정산 금액
+
+    @Column(nullable = false)
+    private Long platformSupportAmount;  // 플랫폼이 지원하는 오차 금액
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/zero/cohousesever/settlement/entity/SettlementHistory.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/SettlementHistory.java
@@ -3,19 +3,19 @@ package com.zero.cohousesever.settlement.entity;
 import com.zero.cohousesever.common.entity.BaseEntity;
 import com.zero.cohousesever.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 /**
  * 정산 히스토리
  */
-@Entity
 @Table(name = "settlement_histories")
+@Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class SettlementHistory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/zero/cohousesever/settlement/entity/SettlementParticipant.java
+++ b/src/main/java/com/zero/cohousesever/settlement/entity/SettlementParticipant.java
@@ -12,7 +12,7 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "settlement_participants")
-public class Participant extends BaseEntity {
+public class SettlementParticipant extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "settlement_id", nullable = false)

--- a/src/main/java/com/zero/cohousesever/settlement/repository/ParticipantRepository.java
+++ b/src/main/java/com/zero/cohousesever/settlement/repository/ParticipantRepository.java
@@ -1,7 +1,0 @@
-package com.zero.cohousesever.settlement.repository;
-
-import com.zero.cohousesever.settlement.entity.Participant;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ParticipantRepository extends JpaRepository<Participant,Long> {
-}

--- a/src/main/java/com/zero/cohousesever/settlement/repository/PaymentHistoryRepository.java
+++ b/src/main/java/com/zero/cohousesever/settlement/repository/PaymentHistoryRepository.java
@@ -1,7 +1,12 @@
 package com.zero.cohousesever.settlement.repository;
 
+import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.settlement.entity.PaymentHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentHistoryRepository extends JpaRepository<PaymentHistory, Long> {
+
+    Optional<PaymentHistory> findBySenderAndSettlementId(Member member, Long settlementId);
 }

--- a/src/main/java/com/zero/cohousesever/settlement/repository/SettlementHistoryRepository.java
+++ b/src/main/java/com/zero/cohousesever/settlement/repository/SettlementHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.zero.cohousesever.settlement.repository;
+
+import com.zero.cohousesever.settlement.entity.SettlementHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementHistoryRepository extends JpaRepository<SettlementHistory, Long> {
+}

--- a/src/main/java/com/zero/cohousesever/settlement/repository/SettlementParticipantRepository.java
+++ b/src/main/java/com/zero/cohousesever/settlement/repository/SettlementParticipantRepository.java
@@ -1,0 +1,7 @@
+package com.zero.cohousesever.settlement.repository;
+
+import com.zero.cohousesever.settlement.entity.SettlementParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SettlementParticipantRepository extends JpaRepository<SettlementParticipant,Long> {
+}

--- a/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
@@ -33,43 +33,27 @@ public class PaymentService {
      */
     public PaymentHistory processPayment(Long memberId, Long settlementId) throws AccessDeniedException {
         Settlement settlement = settlementRepository.findById(settlementId)
-                .orElseThrow(() -> new EntityNotFoundException("NOT FOUND SETTLEMENT"));
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("NOT FOUND MEMBER"));
-
-        // 해당 정산 참여 여부 확인
-        boolean isParticipant = settlement.getParticipants()
-                .stream()
-                .anyMatch(participant -> participant.getMember().getId().equals(memberId));
-        if (!isParticipant) {
-            throw new AccessDeniedException("Member is not part of the settlement");
-        }
+                .orElseThrow(() -> new EntityNotFoundException("Settlement not found with id: " + settlementId));
 
         Participant participant = settlement.getParticipants()
                 .stream()
                 .filter(p -> p.getMember().getId().equals(memberId))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Member is not part of the settlement"));
+                .orElseThrow(() -> new AccessDeniedException("Member is not part of the settlement"));
+
         participant.setStatus(PaymentStatus.PAID);
         participantRepository.save(participant);
 
-        Participant payerParticipant = settlement.getParticipants()
+        Participant payeeParticipant = settlement.getParticipants()
                 .stream()
-                .filter(p -> p.getMember().getId().equals(member.getId()))
+                .filter(p -> p.getMember().getId().equals(settlement.getPayer().getId()))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Member is not part of the settlement"));
+                .orElseThrow(() -> new IllegalStateException("Payer participant not found in the settlement"));
 
-        PaymentHistory paymentHistory = new PaymentHistory();
-        paymentHistory.setSettlement(settlement);
-
-        paymentHistory.setPayer(payerParticipant);
-
-        paymentHistory.setAmount(payerParticipant.getShareAmount());
-        paymentHistory.setTransferDate(LocalDateTime.now());
+        PaymentHistory paymentHistory = PaymentHistory.fromParticipants(settlement, participant, payeeParticipant, participant.getShareAmount());
         paymentHistoryRepository.save(paymentHistory);
 
-        return null;
+        return paymentHistory;
     }
 
     public List<PaymentHistoryResponse> getPaymentHistories(Long groupId, Long settlementId) {

--- a/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
@@ -5,15 +5,13 @@ import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.settlement.dto.PaymentHistoryResponse;
-import com.zero.cohousesever.settlement.entity.SettlementParticipant;
-import com.zero.cohousesever.settlement.entity.PaymentHistory;
-import com.zero.cohousesever.settlement.entity.PaymentStatus;
-import com.zero.cohousesever.settlement.entity.Settlement;
+import com.zero.cohousesever.settlement.entity.*;
 import com.zero.cohousesever.settlement.repository.SettlementParticipantRepository;
 import com.zero.cohousesever.settlement.repository.PaymentHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
@@ -33,6 +31,7 @@ public class PaymentService {
     /**
      * 참여자가 송금 버튼을 눌러 송금 처리
      */
+    @Transactional
     public PaymentHistory processPayment(Long memberId, Long settlementId) throws AccessDeniedException {
         Member member = findMemberOrThrow(memberId);
         Settlement settlement = settlementRepository.findById(settlementId)
@@ -60,11 +59,20 @@ public class PaymentService {
 
         try {
             boolean paymentSuccess = true; // 송금 성공
-//            boolean paymentSuccess = false; // 송금 실패 가정
-
+//        boolean paymentSuccess = false; // 송금 실패 가정
             if (paymentSuccess) {
                 sender.setStatus(PaymentStatus.PAID);
                 settlementParticipantRepository.save(sender);
+
+                // 모든 참여자 상태가 PAID인지 검사
+                boolean allPaid = settlement.getSettlementParticipants()
+                        .stream()
+                        .allMatch(p -> p.getStatus() == PaymentStatus.PAID);
+
+                if (allPaid) {
+                    settlement.setStatus(SettlementStatus.COMPLETED);
+                    settlementRepository.save(settlement);
+                }
 
                 paymentHistory.setStatus(PaymentStatus.PAID);
             } else {

--- a/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
@@ -44,8 +44,10 @@ public class PaymentService {
                 .findFirst()
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_A_SETTLEMENT_PARTICIPANT));
 
-        Member receiver = Optional.ofNullable(settlement.getPayer())
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_THE_SETTLEMENT_PAYER));
+        Member receiver = settlement.getPayer();
+        if (receiver == null) {
+            throw new CustomException(ErrorCode.NOT_THE_SETTLEMENT_PAYER);
+        }
 
         PaymentHistory paymentHistory = PaymentHistory.builder()
                 .settlement(settlement)

--- a/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
@@ -47,12 +47,14 @@ public class PaymentService {
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Payer participant not found in the settlement"));
 
-        PaymentHistory paymentHistory = new PaymentHistory();
-        paymentHistory.setSettlement(settlement);
-        paymentHistory.setSender(participant);
-        paymentHistory.setReceiver(payeeParticipant);
-        paymentHistory.setAmount(participant.getShareAmount());
-        paymentHistory.setTransferDate(LocalDateTime.now());
+        PaymentHistory paymentHistory = PaymentHistory.builder()
+                .settlement(settlement)
+                .sender(participant)
+                .receiver(payeeParticipant)
+                .amount(participant.getShareAmount())
+                .transferDate(LocalDateTime.now())
+                .status(PaymentStatus.PAID)
+                .build();
 
         try {
             boolean paymentSuccess = true; // 송금 성공

--- a/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
@@ -1,16 +1,17 @@
 package com.zero.cohousesever.settlement.service;
 
+import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.settlement.dto.PaymentHistoryResponse;
-import com.zero.cohousesever.settlement.entity.Participant;
+import com.zero.cohousesever.settlement.entity.SettlementParticipant;
 import com.zero.cohousesever.settlement.entity.PaymentHistory;
 import com.zero.cohousesever.settlement.entity.PaymentStatus;
 import com.zero.cohousesever.settlement.entity.Settlement;
-import com.zero.cohousesever.settlement.repository.ParticipantRepository;
+import com.zero.cohousesever.settlement.repository.SettlementParticipantRepository;
 import com.zero.cohousesever.settlement.repository.PaymentHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,7 @@ import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -26,32 +28,30 @@ public class PaymentService {
     private final SettlementRepository settlementRepository;
     private final MemberRepository memberRepository;
     private final PaymentHistoryRepository paymentHistoryRepository;
-    private final ParticipantRepository participantRepository;
+    private final SettlementParticipantRepository settlementParticipantRepository;
 
     /**
      * 참여자가 송금 버튼을 눌러 송금 처리
      */
     public PaymentHistory processPayment(Long memberId, Long settlementId) throws AccessDeniedException {
+        Member member = findMemberOrThrow(memberId);
         Settlement settlement = settlementRepository.findById(settlementId)
-                .orElseThrow(() -> new EntityNotFoundException("Settlement not found with id: " + settlementId));
+                .orElseThrow(() -> new CustomException(ErrorCode.SETTLEMENT_NOT_FOUND));
 
-        Participant participant = settlement.getParticipants()
+        SettlementParticipant sender = settlement.getSettlementParticipants()
                 .stream()
                 .filter(p -> p.getMember().getId().equals(memberId))
                 .findFirst()
-                .orElseThrow(() -> new AccessDeniedException("Member is not part of the settlement"));
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_A_SETTLEMENT_PARTICIPANT));
 
-        Participant payeeParticipant = settlement.getParticipants()
-                .stream()
-                .filter(p -> p.getMember().getId().equals(settlement.getPayer().getId()))
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Payer participant not found in the settlement"));
+        Member receiver = Optional.ofNullable(settlement.getPayer())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_THE_SETTLEMENT_PAYER));
 
         PaymentHistory paymentHistory = PaymentHistory.builder()
                 .settlement(settlement)
-                .sender(participant)
-                .receiver(payeeParticipant)
-                .amount(participant.getShareAmount())
+                .sender(member)
+                .receiver(receiver)
+                .amount(sender.getShareAmount())
                 .transferDate(LocalDateTime.now())
                 .status(PaymentStatus.PAID)
                 .build();
@@ -61,8 +61,8 @@ public class PaymentService {
 //            boolean paymentSuccess = false; // 송금 실패 가정
 
             if (paymentSuccess) {
-                participant.setStatus(PaymentStatus.PAID);
-                participantRepository.save(participant);
+                sender.setStatus(PaymentStatus.PAID);
+                settlementParticipantRepository.save(sender);
 
                 paymentHistory.setStatus(PaymentStatus.PAID);
             } else {
@@ -88,5 +88,11 @@ public class PaymentService {
     //FIXME status ENUM으로 변경
     public List<PaymentHistoryResponse> getMyPaymentsInGroup(Long groupId, Long SettlementId, String status, LocalDate fromDate, LocalDate toDate) {
         return null;
+    }
+
+    // 회원 엔티티 조회 메서드
+    private Member findMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
@@ -41,16 +41,35 @@ public class PaymentService {
                 .findFirst()
                 .orElseThrow(() -> new AccessDeniedException("Member is not part of the settlement"));
 
-        participant.setStatus(PaymentStatus.PAID);
-        participantRepository.save(participant);
-
         Participant payeeParticipant = settlement.getParticipants()
                 .stream()
                 .filter(p -> p.getMember().getId().equals(settlement.getPayer().getId()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Payer participant not found in the settlement"));
 
-        PaymentHistory paymentHistory = PaymentHistory.fromParticipants(settlement, participant, payeeParticipant, participant.getShareAmount());
+        PaymentHistory paymentHistory = new PaymentHistory();
+        paymentHistory.setSettlement(settlement);
+        paymentHistory.setSender(participant);
+        paymentHistory.setReceiver(payeeParticipant);
+        paymentHistory.setAmount(participant.getShareAmount());
+        paymentHistory.setTransferDate(LocalDateTime.now());
+
+        try {
+            boolean paymentSuccess = true; // 송금 성공
+//            boolean paymentSuccess = false; // 송금 실패 가정
+
+            if (paymentSuccess) {
+                participant.setStatus(PaymentStatus.PAID);
+                participantRepository.save(participant);
+
+                paymentHistory.setStatus(PaymentStatus.PAID);
+            } else {
+                paymentHistory.setStatus(PaymentStatus.FAILED);
+            }
+        } catch (Exception e) {
+            paymentHistory.setStatus(PaymentStatus.FAILED);
+        }
+
         paymentHistoryRepository.save(paymentHistory);
 
         return paymentHistory;

--- a/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
@@ -6,6 +6,7 @@ import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.settlement.dto.PaymentHistoryResponse;
 import com.zero.cohousesever.settlement.entity.*;
+import com.zero.cohousesever.settlement.repository.SettlementHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementParticipantRepository;
 import com.zero.cohousesever.settlement.repository.PaymentHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
@@ -25,6 +26,7 @@ public class PaymentService {
 
     private final SettlementRepository settlementRepository;
     private final MemberRepository memberRepository;
+    private final SettlementHistoryRepository settlementHistoryRepository;
     private final PaymentHistoryRepository paymentHistoryRepository;
     private final SettlementParticipantRepository settlementParticipantRepository;
 
@@ -71,6 +73,13 @@ public class PaymentService {
 
                 if (allPaid) {
                     settlement.setStatus(SettlementStatus.COMPLETED);
+                    SettlementHistory completionHistory = SettlementHistory.builder()
+                            .settlement(settlement)
+                            .status(SettlementStatus.COMPLETED)
+                            .changedAt(LocalDateTime.now())
+                            .build();
+
+                    settlementHistoryRepository.save(completionHistory);
                     settlementRepository.save(settlement);
                 }
 

--- a/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/PaymentService.java
@@ -1,31 +1,74 @@
 package com.zero.cohousesever.settlement.service;
 
+import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.settlement.dto.PaymentHistoryResponse;
 import com.zero.cohousesever.settlement.entity.Participant;
 import com.zero.cohousesever.settlement.entity.PaymentHistory;
+import com.zero.cohousesever.settlement.entity.PaymentStatus;
+import com.zero.cohousesever.settlement.entity.Settlement;
 import com.zero.cohousesever.settlement.repository.ParticipantRepository;
 import com.zero.cohousesever.settlement.repository.PaymentHistoryRepository;
+import com.zero.cohousesever.settlement.repository.SettlementRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
 
+    private final SettlementRepository settlementRepository;
+    private final MemberRepository memberRepository;
     private final PaymentHistoryRepository paymentHistoryRepository;
     private final ParticipantRepository participantRepository;
 
     /**
-     * TODO 참여자가 송금 버튼을 눌러 송금 처리
+     * 참여자가 송금 버튼을 눌러 송금 처리
      */
-    public PaymentHistory processPayment(Long participantId, Participant payee, Long amount) {
-        // 1. 송금 API 호출
-        // 2. 송금 거래 내역 생성 및 저장
-        // 3. 참여자의 송금 상태 업데이트 및 저장
-        // 4. 저장된 거래 이력 반환
+    public PaymentHistory processPayment(Long memberId, Long settlementId) throws AccessDeniedException {
+        Settlement settlement = settlementRepository.findById(settlementId)
+                .orElseThrow(() -> new EntityNotFoundException("NOT FOUND SETTLEMENT"));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("NOT FOUND MEMBER"));
+
+        // 해당 정산 참여 여부 확인
+        boolean isParticipant = settlement.getParticipants()
+                .stream()
+                .anyMatch(participant -> participant.getMember().getId().equals(memberId));
+        if (!isParticipant) {
+            throw new AccessDeniedException("Member is not part of the settlement");
+        }
+
+        Participant participant = settlement.getParticipants()
+                .stream()
+                .filter(p -> p.getMember().getId().equals(memberId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Member is not part of the settlement"));
+        participant.setStatus(PaymentStatus.PAID);
+        participantRepository.save(participant);
+
+        Participant payerParticipant = settlement.getParticipants()
+                .stream()
+                .filter(p -> p.getMember().getId().equals(member.getId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Member is not part of the settlement"));
+
+        PaymentHistory paymentHistory = new PaymentHistory();
+        paymentHistory.setSettlement(settlement);
+
+        paymentHistory.setPayer(payerParticipant);
+
+        paymentHistory.setAmount(payerParticipant.getShareAmount());
+        paymentHistory.setTransferDate(LocalDateTime.now());
+        paymentHistoryRepository.save(paymentHistory);
+
         return null;
     }
 

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -132,6 +132,14 @@ public class SettlementService {
     }
 
     /**
+     * 정산 취소 처리
+     */
+    public void cancelSettlement(Long memberId, Long SettlementId) {
+        Member member = findMemberOrThrow(memberId);
+
+    }
+
+    /**
      * 정산 목록 조회 (페이징 및 필터링 포함)
      */
     public void getSettlements() {
@@ -144,27 +152,9 @@ public class SettlementService {
     }
 
     /**
-     * 정산 삭제 또는 취소 처리
-     */
-    public void deleteSettlement() {
-    }
-
-    /**
      * 정산 참여자 목록 조회
      */
     public void getParticipants() {
-    }
-
-    /**
-     * 정산 참여자 추가
-     */
-    public void addParticipant() {
-    }
-
-    /**
-     * 정산 참여자 제거
-     */
-    public void removeParticipant() {
     }
 
     /**

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -15,13 +15,8 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -49,36 +44,56 @@ public class SettlementService {
         Set<Long> allParticipantIds = new HashSet<>(request.getParticipantIds());
         allParticipantIds.add(payerId); // 결제자 ID도 포함시킴
 
-        List<Participant> participants = new ArrayList<>();
-        for (Long memberId : allParticipantIds) {
-            Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
+        if (request.isEqualDistribution()) {
+            // 솜금 금액 균등 분배 시
+            Long shareAmount = calculateShareAmount(request.getSettlementAmount(), allParticipantIds.size());
+            Long roundingAmount = request.getSettlementAmount() % allParticipantIds.size();
+            settlement.setPlatformSupportAmount(roundingAmount);
 
-            Participant participant = new Participant();
-            participant.setMember(member);
-            participant.setSettlement(settlement);
+            List<Participant> participants = new ArrayList<>();
+            for (Long memberId : allParticipantIds) {
+                Member member = memberRepository.findById(memberId)
+                        .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
 
-            if(memberId.equals(payerId)) {
-                participant.setStatus(PaymentStatus.PAID); // 결제자: 송금 완료 상태
-            } else {
-                participant.setStatus(PaymentStatus.PENDING); // 참여자: 대기 상태
+                Participant participant = new Participant();
+                participant.setMember(member);
+                participant.setSettlement(settlement);
+
+                if (memberId.equals(payerId)) {
+                    participant.setStatus(PaymentStatus.PAID); // 결제자: 송금 완료 상태
+                } else {
+                    participant.setStatus(PaymentStatus.PENDING); // 참여자: 대기 상태
+                }
+                participant.setShareAmount(shareAmount);
+                participants.add(participant);
             }
+            settlement.setParticipants(participants);
 
-            participant.setShareAmount(calculateShareAmount(request.getSettlementAmount(), allParticipantIds.size()));
-            participants.add(participant);
+        } else {
+//            // 송금 금액 직접 분배 시
+//            Long manualShares = request.getManualSharedAmount();
+//            Long sumShares = manualShares.values().stream().mapToLong(Long::longValue).sum();
+//            if (!sumShares.equals(request.getSettlementAmount())) {
+//                throw new IllegalArgumentException("참여자별 분배 금액 합계가 총 정산 금액과 일치하지 않습니다.");
+//            }
+//
+//            settlement.setPlatformSupportAmount(0L); // 오차 없음
+//
+//            for (Long memberId : allParticipantIds) {
+//                participant.setShareAmount(manualShares.get(memberId));
+//            }
         }
-        settlement.setParticipants(participants);
         Settlement savedSettlement = settlementRepository.save(settlement);
+
         return SettlementDto.fromEntity(savedSettlement);
     }
 
     // 배분 금액 계산 함수
-    public BigDecimal calculateShareAmount(BigDecimal totalAmount, int participantCount) {
-        //TODO 똑같이 분배되지 않는 경우에 대한 로직 필요
+    public Long calculateShareAmount(Long totalAmount, int participantCount) {
         if (participantCount <= 0) {
             throw new IllegalArgumentException("참여자 수는 1 이상이어야 합니다.");
         }
-        return totalAmount.divide(BigDecimal.valueOf(participantCount), 2, RoundingMode.HALF_UP);
+        return totalAmount / participantCount;
     }
 
     /**

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -19,7 +19,9 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +33,10 @@ public class SettlementService {
     /**
      * 정산 등록
      */
-    public SettlementDto createSettlement(CreateSettlementRequest request) {
+    public SettlementDto createSettlement(Long payerId, CreateSettlementRequest request) {
+        Member payer = memberRepository.findById(payerId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + payerId));
+
         Settlement settlement = new Settlement();
         settlement.setTitle(request.getTitle());
         settlement.setDescription(request.getDescription());
@@ -39,27 +44,37 @@ public class SettlementService {
 
         settlement.setSettlementAmount(request.getSettlementAmount());
         settlement.setStatus(SettlementStatus.PENDING);
+        settlement.setPayer(payer);
+
+        Set<Long> allParticipantIds = new HashSet<>(request.getParticipantIds());
+        allParticipantIds.add(payerId); // 결제자 ID도 포함시킴
 
         List<Participant> participants = new ArrayList<>();
-        for (Long memberId : request.getParticipantIds()) {
+        for (Long memberId : allParticipantIds) {
             Member member = memberRepository.findById(memberId)
                     .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
 
             Participant participant = new Participant();
             participant.setMember(member);
             participant.setSettlement(settlement);
-            participant.setStatus(PaymentStatus.PENDING);
-            participant.setShareAmount(calculateShareAmount(request.getSettlementAmount(), request.getParticipantIds().size()));
+
+            if(memberId.equals(payerId)) {
+                participant.setStatus(PaymentStatus.PAID); // 결제자: 송금 완료 상태
+            } else {
+                participant.setStatus(PaymentStatus.PENDING); // 참여자: 대기 상태
+            }
+
+            participant.setShareAmount(calculateShareAmount(request.getSettlementAmount(), allParticipantIds.size()));
             participants.add(participant);
         }
         settlement.setParticipants(participants);
-
         Settlement savedSettlement = settlementRepository.save(settlement);
         return SettlementDto.fromEntity(savedSettlement);
     }
 
     // 배분 금액 계산 함수
     public BigDecimal calculateShareAmount(BigDecimal totalAmount, int participantCount) {
+        //TODO 똑같이 분배되지 않는 경우에 대한 로직 필요
         if (participantCount <= 0) {
             throw new IllegalArgumentException("참여자 수는 1 이상이어야 합니다.");
         }

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -163,9 +163,6 @@ public class SettlementService {
 
         // 정산 참여자 상태 변경 및 송금 히스토리 생성
         for (SettlementParticipant participant : settlement.getSettlementParticipants()) {
-            if (!participant.getMember().getId().equals(memberId)) {
-                continue;
-            }
 
             PaymentStatus previousStatus = participant.getStatus();
 

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -13,11 +13,10 @@ import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
 import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
 import com.zero.cohousesever.settlement.entity.*;
-import com.zero.cohousesever.settlement.repository.SettlementParticipantRepository;
 import com.zero.cohousesever.settlement.repository.PaymentHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementHistoryRepository;
+import com.zero.cohousesever.settlement.repository.SettlementParticipantRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,6 +55,7 @@ public class SettlementService {
                 .status(SettlementStatus.PENDING)
                 .payer(payer)
                 .group(group)
+                .isEqualDistribution(request.isEqualDistribution())
                 .build();
 
         Set<Long> allParticipantIds = new HashSet<>(request.getParticipantIds());
@@ -154,32 +154,49 @@ public class SettlementService {
      */
     @Transactional
     public void cancelSettlement(Long memberId, Long settlementId) {
-        Member member = findMemberOrThrow(memberId);
+        findMemberOrThrow(memberId);
         Settlement settlement = findSettlementOrThrow(settlementId);
 
-        PaymentHistory paymentHistory = paymentHistoryRepository
-                .findBySenderAndSettlementId(member, settlementId)
-                .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_HISTORY_NOT_FOUND));
+        if (!settlement.getPayer().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.SETTLEMENT_PERMISSION_DENIED);
+        }
+
+        // 정산 참여자 상태 변경 및 송금 히스토리 생성
+        for (SettlementParticipant participant : settlement.getSettlementParticipants()) {
+            if (!participant.getMember().getId().equals(memberId)) {
+                continue;
+            }
+
+            PaymentStatus previousStatus = participant.getStatus();
+
+            if (previousStatus == PaymentStatus.PAID) {
+                participant.setStatus(PaymentStatus.REFUNDED);
+                // 송금 히스토리 생성: 환불 기록 추가
+                PaymentHistory refundHistory = PaymentHistory.builder()
+                        .sender(participant.getMember())
+                        .receiver(settlement.getPayer())
+                        .settlement(settlement)
+                        .amount(participant.getShareAmount())
+                        .status(PaymentStatus.REFUNDED)
+                        .transferDate(LocalDateTime.now())
+                        .build();
+                paymentHistoryRepository.save(refundHistory);
+
+            } else if (previousStatus == PaymentStatus.PENDING) {
+                participant.setStatus(PaymentStatus.CANCELED);
+            }
+        }
+
+        SettlementHistory.builder()
+                .settlement(settlement)
+                .changedBy(findMemberOrThrow(memberId))
+                .title(settlement.getTitle())
+                .status(SettlementStatus.CANCELED)
+                .changedAt(LocalDateTime.now())
+                .build();
 
         settlement.setStatus(SettlementStatus.CANCELED);
         settlementRepository.save(settlement);
-
-        if (paymentHistory.getStatus() == PaymentStatus.PAID) {
-            paymentHistory.setStatus(PaymentStatus.REFUNDED);
-            paymentHistoryRepository.save(paymentHistory);
-        }
-
-        // 정산 참여자 상태도 함께 업데이트
-        settlement.getSettlementParticipants()
-                .stream()
-                .filter(p -> p.getMember().getId().equals(memberId))
-                .forEach(p -> {
-                    if (p.getStatus() == PaymentStatus.PAID) {
-                        p.setStatus(PaymentStatus.REFUNDED);
-                    } else if (p.getStatus() == PaymentStatus.PENDING) {
-                        p.setStatus(PaymentStatus.CANCELED);
-                    }
-                });
         settlementParticipantRepository.saveAll(settlement.getSettlementParticipants());
     }
 

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -3,7 +3,7 @@ package com.zero.cohousesever.settlement.service;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
-import com.zero.cohousesever.settlement.dto.SettlementDto;
+import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
 import com.zero.cohousesever.settlement.entity.Participant;
 import com.zero.cohousesever.settlement.entity.PaymentStatus;
@@ -28,7 +28,7 @@ public class SettlementService {
     /**
      * 정산 등록
      */
-    public SettlementDto createSettlement(Long payerId, CreateSettlementRequest request) {
+    public SettlementResponseDto createSettlement(Long payerId, CreateSettlementRequest request) {
         Member payer = memberRepository.findById(payerId)
                 .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + payerId));
 
@@ -36,56 +36,73 @@ public class SettlementService {
         settlement.setTitle(request.getTitle());
         settlement.setDescription(request.getDescription());
         settlement.setCategory(request.getCategory());
-
         settlement.setSettlementAmount(request.getSettlementAmount());
         settlement.setStatus(SettlementStatus.PENDING);
         settlement.setPayer(payer);
 
         Set<Long> allParticipantIds = new HashSet<>(request.getParticipantIds());
-        allParticipantIds.add(payerId); // 결제자 ID도 포함시킴
+        allParticipantIds.add(payerId); // 결제자 포함
 
+        List<Participant> participants;
         if (request.isEqualDistribution()) {
-            // 솜금 금액 균등 분배 시
-            Long shareAmount = calculateShareAmount(request.getSettlementAmount(), allParticipantIds.size());
-            Long roundingAmount = request.getSettlementAmount() % allParticipantIds.size();
-            settlement.setPlatformSupportAmount(roundingAmount);
-
-            List<Participant> participants = new ArrayList<>();
-            for (Long memberId : allParticipantIds) {
-                Member member = memberRepository.findById(memberId)
-                        .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
-
-                Participant participant = new Participant();
-                participant.setMember(member);
-                participant.setSettlement(settlement);
-
-                if (memberId.equals(payerId)) {
-                    participant.setStatus(PaymentStatus.PAID); // 결제자: 송금 완료 상태
-                } else {
-                    participant.setStatus(PaymentStatus.PENDING); // 참여자: 대기 상태
-                }
-                participant.setShareAmount(shareAmount);
-                participants.add(participant);
-            }
-            settlement.setParticipants(participants);
-
+            participants = createEqualDistributionParticipants(settlement, allParticipantIds, request.getSettlementAmount());
         } else {
-//            // 송금 금액 직접 분배 시
-//            Long manualShares = request.getManualSharedAmount();
-//            Long sumShares = manualShares.values().stream().mapToLong(Long::longValue).sum();
-//            if (!sumShares.equals(request.getSettlementAmount())) {
-//                throw new IllegalArgumentException("참여자별 분배 금액 합계가 총 정산 금액과 일치하지 않습니다.");
-//            }
-//
-//            settlement.setPlatformSupportAmount(0L); // 오차 없음
-//
-//            for (Long memberId : allParticipantIds) {
-//                participant.setShareAmount(manualShares.get(memberId));
-//            }
+//            participants = createManualDistributionParticipants(settlement, allParticipantIds, request.getManualShares(), request.getSettlementAmount());
         }
+
+        settlement.setParticipants(participants);
         Settlement savedSettlement = settlementRepository.save(settlement);
 
-        return SettlementDto.fromEntity(savedSettlement);
+        return SettlementResponseDto.fromEntity(savedSettlement);
+    }
+
+    // 균등 분배 참여자 생성 메서드
+    private List<Participant> createEqualDistributionParticipants(Settlement settlement, Set<Long> participantIds, Long totalAmount) {
+        Long shareAmount = calculateShareAmount(totalAmount, participantIds.size());
+        Long remainder = totalAmount % participantIds.size();
+        settlement.setPlatformSupportAmount(remainder);
+
+        List<Participant> participants = new ArrayList<>();
+        for (Long memberId : participantIds) {
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
+
+            Participant participant = new Participant();
+            participant.setMember(member);
+            participant.setSettlement(settlement);
+            participant.setStatus(memberId.equals(settlement.getPayer().getId()) ? PaymentStatus.PAID : PaymentStatus.PENDING);
+            participant.setShareAmount(shareAmount);
+            participants.add(participant);
+        }
+        return participants;
+    }
+
+    // 수동 분배 참여자 생성 메서드
+    private List<Participant> createManualDistributionParticipants(Settlement settlement, Set<Long> participantIds, Map<Long, Long> manualShares, Long totalAmount) {
+        if (manualShares == null || manualShares.isEmpty()) {
+            throw new IllegalArgumentException("Manual shares must be provided for manual distribution.");
+        }
+
+        Long sumShares = manualShares.values().stream().mapToLong(Long::longValue).sum();
+        if (!sumShares.equals(totalAmount)) {
+            throw new IllegalArgumentException("Sum of manual shares does not match total amount.");
+        }
+
+        settlement.setPlatformSupportAmount(0L); // 오차 없음
+
+        List<Participant> participants = new ArrayList<>();
+        for (Long memberId : participantIds) {
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
+
+            Participant participant = new Participant();
+            participant.setMember(member);
+            participant.setSettlement(settlement);
+            participant.setStatus(memberId.equals(settlement.getPayer().getId()) ? PaymentStatus.PAID : PaymentStatus.PENDING);
+            participant.setShareAmount(manualShares.getOrDefault(memberId, 0L));
+            participants.add(participant);
+        }
+        return participants;
     }
 
     // 배분 금액 계산 함수

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -91,8 +91,7 @@ public class SettlementService {
 
         List<SettlementParticipant> settlementParticipants = new ArrayList<>();
         for (Long memberId : participantIds) {
-            Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
+            Member member = findMemberOrThrow(memberId);
 
             SettlementParticipant settlementParticipant = SettlementParticipant.builder()
                     .member(member)
@@ -108,12 +107,11 @@ public class SettlementService {
     // 수동 분배 참여자 생성 메서드
     private List<SettlementParticipant> createManualDistributionParticipants(Settlement settlement, Set<Long> participantIds, Map<Long, Long> manualShares, Long totalAmount) {
         if (manualShares == null || manualShares.isEmpty()) {
-            throw new IllegalArgumentException("Manual shares must be provided for manual distribution.");
+            throw new CustomException(ErrorCode.INVALID_MANUAL_DISTRIBUTION);
         }
 
         // 참여자들의 금액의 합이 맞는지 계산
         Long sumShares = manualShares.values().stream().mapToLong(Long::longValue).sum();
-        System.out.println(sumShares);
         Long payerId = settlement.getPayer().getId();
 
         // 결제자 부담금 계산
@@ -121,7 +119,7 @@ public class SettlementService {
 
         // 분배 금액 합이 정산 금액을 초과하면 예외 처리
         if (payerShare < 0) {
-            throw new IllegalArgumentException("The sum of distributed amounts exceeds the total settlement amount");
+            throw new CustomException(ErrorCode.EXCEED_TOTAL_AMOUNT);
         }
 
         manualShares.put(payerId, payerShare);
@@ -144,7 +142,7 @@ public class SettlementService {
     // 배분 금액 계산 메서드
     public Long calculateShareAmount(Long totalAmount, int participantCount) {
         if (participantCount <= 0) {
-            throw new IllegalArgumentException("Participant count must be at least 1.");
+            throw new CustomException(ErrorCode.INVALID_PARTICIPANT_COUNT);
         }
         return totalAmount / participantCount;
     }

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -3,8 +3,8 @@ package com.zero.cohousesever.settlement.service;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
-import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
+import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
 import com.zero.cohousesever.settlement.entity.Participant;
 import com.zero.cohousesever.settlement.entity.PaymentStatus;
 import com.zero.cohousesever.settlement.entity.Settlement;
@@ -43,11 +43,11 @@ public class SettlementService {
         Set<Long> allParticipantIds = new HashSet<>(request.getParticipantIds());
         allParticipantIds.add(payerId); // 결제자 포함
 
-        List<Participant> participants;
+        List<Participant> participants = new ArrayList<>();
         if (request.isEqualDistribution()) {
             participants = createEqualDistributionParticipants(settlement, allParticipantIds, request.getSettlementAmount());
         } else {
-//            participants = createManualDistributionParticipants(settlement, allParticipantIds, request.getManualShares(), request.getSettlementAmount());
+            participants = createManualDistributionParticipants(settlement, allParticipantIds, request.getManualShares(), request.getSettlementAmount());
         }
 
         settlement.setParticipants(participants);
@@ -83,18 +83,26 @@ public class SettlementService {
             throw new IllegalArgumentException("Manual shares must be provided for manual distribution.");
         }
 
+        // 참여자들의 금액의 합이 맞는지 계산
         Long sumShares = manualShares.values().stream().mapToLong(Long::longValue).sum();
-        if (!sumShares.equals(totalAmount)) {
-            throw new IllegalArgumentException("Sum of manual shares does not match total amount.");
+        System.out.println(sumShares);
+        Long payerId = settlement.getPayer().getId();
+
+        // 결제자 부담금 계산
+        Long payerShare = totalAmount - sumShares;
+
+        // 분배 금액 합이 정산 금액을 초과하면 예외 처리
+        if (payerShare < 0) {
+            throw new IllegalArgumentException("The sum of distributed amounts exceeds the total settlement amount");
         }
 
-        settlement.setPlatformSupportAmount(0L); // 오차 없음
+        manualShares.put(payerId, payerShare);
+
+        settlement.setPlatformSupportAmount(0L); // 플랫폼 오차 지원금 없음
 
         List<Participant> participants = new ArrayList<>();
         for (Long memberId : participantIds) {
-            Member member = memberRepository.findById(memberId)
-                    .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
-
+            Member member = findMemberOrThrow(memberId);
             Participant participant = new Participant();
             participant.setMember(member);
             participant.setSettlement(settlement);
@@ -105,10 +113,10 @@ public class SettlementService {
         return participants;
     }
 
-    // 배분 금액 계산 함수
+    // 배분 금액 계산 메서드
     public Long calculateShareAmount(Long totalAmount, int participantCount) {
         if (participantCount <= 0) {
-            throw new IllegalArgumentException("참여자 수는 1 이상이어야 합니다.");
+            throw new IllegalArgumentException("Participant count must be at least 1.");
         }
         return totalAmount / participantCount;
     }
@@ -167,5 +175,11 @@ public class SettlementService {
      */
     public List<SettlementHistoryResponse> getGroupSettlementHistories(Long groupId, Long settlementId, LocalDate fromDate, LocalDate toDate) {
         return null;
+    }
+
+    // 회원 엔티티 조회 메서드
+    private Member findMemberOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
     }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -1,12 +1,24 @@
 package com.zero.cohousesever.settlement.service;
 
+import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.repository.MemberRepository;
+import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
+import com.zero.cohousesever.settlement.dto.SettlementDto;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
+import com.zero.cohousesever.settlement.entity.Participant;
+import com.zero.cohousesever.settlement.entity.PaymentStatus;
+import com.zero.cohousesever.settlement.entity.Settlement;
+import com.zero.cohousesever.settlement.entity.SettlementStatus;
 import com.zero.cohousesever.settlement.repository.ParticipantRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -14,19 +26,50 @@ import java.util.List;
 public class SettlementService {
     private final SettlementRepository settlementRepository;
     private final ParticipantRepository participantRepository;
+    private final MemberRepository memberRepository;
 
-    // TODO: 실제 서비스 로직 구현 예정
+    /**
+     * 정산 등록
+     */
+    public SettlementDto createSettlement(CreateSettlementRequest request) {
+        Settlement settlement = new Settlement();
+        settlement.setTitle(request.getTitle());
+        settlement.setDescription(request.getDescription());
+        settlement.setCategory(request.getCategory());
+
+        settlement.setSettlementAmount(request.getSettlementAmount());
+        settlement.setStatus(SettlementStatus.PENDING);
+
+        List<Participant> participants = new ArrayList<>();
+        for (Long memberId : request.getParticipantIds()) {
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
+
+            Participant participant = new Participant();
+            participant.setMember(member);
+            participant.setSettlement(settlement);
+            participant.setStatus(PaymentStatus.PENDING);
+            participant.setShareAmount(calculateShareAmount(request.getSettlementAmount(), request.getParticipantIds().size()));
+            participants.add(participant);
+        }
+        settlement.setParticipants(participants);
+
+        Settlement savedSettlement = settlementRepository.save(settlement);
+        return SettlementDto.fromEntity(savedSettlement);
+    }
+
+    // 배분 금액 계산 함수
+    public BigDecimal calculateShareAmount(BigDecimal totalAmount, int participantCount) {
+        if (participantCount <= 0) {
+            throw new IllegalArgumentException("참여자 수는 1 이상이어야 합니다.");
+        }
+        return totalAmount.divide(BigDecimal.valueOf(participantCount), 2, RoundingMode.HALF_UP);
+    }
 
     /**
      * 정산 목록 조회 (페이징 및 필터링 포함)
      */
     public void getSettlements() {
-    }
-
-    /**
-     * 신규 정산 등록
-     */
-    public void createSettlement() {
     }
 
     /**

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -1,20 +1,26 @@
 package com.zero.cohousesever.settlement.service;
 
 
+import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.common.exception.ErrorCode;
+import com.zero.cohousesever.group.entity.Group;
+import com.zero.cohousesever.group.entity.GroupMember;
+import com.zero.cohousesever.group.enums.GroupMemberStatus;
+import com.zero.cohousesever.group.repository.GroupMemberRepository;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
-import com.zero.cohousesever.common.exception.CustomException;
-import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
 import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
 import com.zero.cohousesever.settlement.entity.*;
-import com.zero.cohousesever.settlement.repository.ParticipantRepository;
+import com.zero.cohousesever.settlement.repository.SettlementParticipantRepository;
+import com.zero.cohousesever.settlement.repository.PaymentHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -24,15 +30,23 @@ import java.util.*;
 @RequiredArgsConstructor
 public class SettlementService {
     public final MemberRepository memberRepository;
+    public final GroupMemberRepository groupMemberRepository;
+    public final SettlementParticipantRepository settlementParticipantRepository;
     private final SettlementRepository settlementRepository;
     private final SettlementHistoryRepository settlementHistoryRepository;
+    private final PaymentHistoryRepository paymentHistoryRepository;
 
     /**
      * 정산 등록
      */
     public SettlementResponseDto createSettlement(Long payerId, CreateSettlementRequest request) {
         Member payer = memberRepository.findById(payerId)
-                .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + payerId));
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        Group group = groupMemberRepository
+                .findByMemberIdAndStatus(payerId, GroupMemberStatus.ACTIVE)
+                .map(GroupMember::getGroup)
+                .orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND));
 
         Settlement settlement = Settlement.builder()
                 .title(request.getTitle())
@@ -41,19 +55,20 @@ public class SettlementService {
                 .settlementAmount(request.getSettlementAmount())
                 .status(SettlementStatus.PENDING)
                 .payer(payer)
+                .group(group)
                 .build();
 
         Set<Long> allParticipantIds = new HashSet<>(request.getParticipantIds());
         allParticipantIds.add(payerId); // 결제자 포함
 
-        List<Participant> participants = new ArrayList<>();
+        List<SettlementParticipant> settlementParticipants = new ArrayList<>();
         if (request.isEqualDistribution()) {
-            participants = createEqualDistributionParticipants(settlement, allParticipantIds, request.getSettlementAmount());
+            settlementParticipants = createEqualDistributionParticipants(settlement, allParticipantIds, request.getSettlementAmount());
         } else {
-            participants = createManualDistributionParticipants(settlement, allParticipantIds, request.getManualShares(), request.getSettlementAmount());
+            settlementParticipants = createManualDistributionParticipants(settlement, allParticipantIds, request.getManualShares(), request.getSettlementAmount());
         }
 
-        settlement.setParticipants(participants);
+        settlement.setSettlementParticipants(settlementParticipants);
         Settlement savedSettlement = settlementRepository.save(settlement);
 
         SettlementHistory history = SettlementHistory.builder()
@@ -69,29 +84,29 @@ public class SettlementService {
     }
 
     // 균등 분배 참여자 생성 메서드
-    private List<Participant> createEqualDistributionParticipants(Settlement settlement, Set<Long> participantIds, Long totalAmount) {
+    private List<SettlementParticipant> createEqualDistributionParticipants(Settlement settlement, Set<Long> participantIds, Long totalAmount) {
         Long shareAmount = calculateShareAmount(totalAmount, participantIds.size());
         Long remainder = totalAmount % participantIds.size();
         settlement.setPlatformSupportAmount(remainder);
 
-        List<Participant> participants = new ArrayList<>();
+        List<SettlementParticipant> settlementParticipants = new ArrayList<>();
         for (Long memberId : participantIds) {
             Member member = memberRepository.findById(memberId)
                     .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
 
-            Participant participant = Participant.builder()
+            SettlementParticipant settlementParticipant = SettlementParticipant.builder()
                     .member(member)
                     .settlement(settlement)
                     .status(memberId.equals(settlement.getPayer().getId()) ? PaymentStatus.PAID : PaymentStatus.PENDING)
                     .shareAmount(shareAmount)
                     .build();
-            participants.add(participant);
+            settlementParticipants.add(settlementParticipant);
         }
-        return participants;
+        return settlementParticipants;
     }
 
     // 수동 분배 참여자 생성 메서드
-    private List<Participant> createManualDistributionParticipants(Settlement settlement, Set<Long> participantIds, Map<Long, Long> manualShares, Long totalAmount) {
+    private List<SettlementParticipant> createManualDistributionParticipants(Settlement settlement, Set<Long> participantIds, Map<Long, Long> manualShares, Long totalAmount) {
         if (manualShares == null || manualShares.isEmpty()) {
             throw new IllegalArgumentException("Manual shares must be provided for manual distribution.");
         }
@@ -113,17 +128,17 @@ public class SettlementService {
 
         settlement.setPlatformSupportAmount(0L); // 플랫폼 오차 지원금 없음
 
-        List<Participant> participants = new ArrayList<>();
+        List<SettlementParticipant> settlementParticipants = new ArrayList<>();
         for (Long memberId : participantIds) {
             Member member = findMemberOrThrow(memberId);
-            Participant participant = new Participant();
-            participant.setMember(member);
-            participant.setSettlement(settlement);
-            participant.setStatus(memberId.equals(settlement.getPayer().getId()) ? PaymentStatus.PAID : PaymentStatus.PENDING);
-            participant.setShareAmount(manualShares.getOrDefault(memberId, 0L));
-            participants.add(participant);
+            SettlementParticipant settlementParticipant = new SettlementParticipant();
+            settlementParticipant.setMember(member);
+            settlementParticipant.setSettlement(settlement);
+            settlementParticipant.setStatus(memberId.equals(settlement.getPayer().getId()) ? PaymentStatus.PAID : PaymentStatus.PENDING);
+            settlementParticipant.setShareAmount(manualShares.getOrDefault(memberId, 0L));
+            settlementParticipants.add(settlementParticipant);
         }
-        return participants;
+        return settlementParticipants;
     }
 
     // 배분 금액 계산 메서드
@@ -136,10 +151,38 @@ public class SettlementService {
 
     /**
      * 정산 취소 처리
+     *
+     * - 정산 취소 시 송금을 한 정산 참여자만 환불 상태로 변경
      */
-    public void cancelSettlement(Long memberId, Long SettlementId) {
+    @Transactional
+    public void cancelSettlement(Long memberId, Long settlementId) {
         Member member = findMemberOrThrow(memberId);
+        Settlement settlement = findSettlementOrThrow(settlementId);
 
+        PaymentHistory paymentHistory = paymentHistoryRepository
+                .findBySenderAndSettlementId(member, settlementId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PAYMENT_HISTORY_NOT_FOUND));
+
+        settlement.setStatus(SettlementStatus.CANCELED);
+        settlementRepository.save(settlement);
+
+        if (paymentHistory.getStatus() == PaymentStatus.PAID) {
+            paymentHistory.setStatus(PaymentStatus.REFUNDED);
+            paymentHistoryRepository.save(paymentHistory);
+        }
+
+        // 정산 참여자 상태도 함께 업데이트
+        settlement.getSettlementParticipants()
+                .stream()
+                .filter(p -> p.getMember().getId().equals(memberId))
+                .forEach(p -> {
+                    if (p.getStatus() == PaymentStatus.PAID) {
+                        p.setStatus(PaymentStatus.REFUNDED);
+                    } else if (p.getStatus() == PaymentStatus.PENDING) {
+                        p.setStatus(PaymentStatus.CANCELED);
+                    }
+                });
+        settlementParticipantRepository.saveAll(settlement.getSettlementParticipants());
     }
 
     /**
@@ -183,6 +226,12 @@ public class SettlementService {
     // 회원 엔티티 조회 메서드
     private Member findMemberOrThrow(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    // 정산 엔티티 조회 메서드
+    private Settlement findSettlementOrThrow(Long settlementId) {
+        return settlementRepository.findById(settlementId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SETTLEMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -32,13 +32,14 @@ public class SettlementService {
         Member payer = memberRepository.findById(payerId)
                 .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + payerId));
 
-        Settlement settlement = new Settlement();
-        settlement.setTitle(request.getTitle());
-        settlement.setDescription(request.getDescription());
-        settlement.setCategory(request.getCategory());
-        settlement.setSettlementAmount(request.getSettlementAmount());
-        settlement.setStatus(SettlementStatus.PENDING);
-        settlement.setPayer(payer);
+        Settlement settlement = Settlement.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .category(request.getCategory())
+                .settlementAmount(request.getSettlementAmount())
+                .status(SettlementStatus.PENDING)
+                .payer(payer)
+                .build();
 
         Set<Long> allParticipantIds = new HashSet<>(request.getParticipantIds());
         allParticipantIds.add(payerId); // 결제자 포함
@@ -67,11 +68,12 @@ public class SettlementService {
             Member member = memberRepository.findById(memberId)
                     .orElseThrow(() -> new EntityNotFoundException("Member not found with id: " + memberId));
 
-            Participant participant = new Participant();
-            participant.setMember(member);
-            participant.setSettlement(settlement);
-            participant.setStatus(memberId.equals(settlement.getPayer().getId()) ? PaymentStatus.PAID : PaymentStatus.PENDING);
-            participant.setShareAmount(shareAmount);
+            Participant participant = Participant.builder()
+                    .member(member)
+                    .settlement(settlement)
+                    .status(memberId.equals(settlement.getPayer().getId()) ? PaymentStatus.PAID : PaymentStatus.PENDING)
+                    .shareAmount(shareAmount)
+                    .build();
             participants.add(participant);
         }
         return participants;

--- a/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
+++ b/src/main/java/com/zero/cohousesever/settlement/service/SettlementService.java
@@ -5,24 +5,23 @@ import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
 import com.zero.cohousesever.settlement.dto.SettlementHistoryResponse;
 import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
-import com.zero.cohousesever.settlement.entity.Participant;
-import com.zero.cohousesever.settlement.entity.PaymentStatus;
-import com.zero.cohousesever.settlement.entity.Settlement;
-import com.zero.cohousesever.settlement.entity.SettlementStatus;
+import com.zero.cohousesever.settlement.entity.*;
 import com.zero.cohousesever.settlement.repository.ParticipantRepository;
+import com.zero.cohousesever.settlement.repository.SettlementHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class SettlementService {
     private final SettlementRepository settlementRepository;
-    private final ParticipantRepository participantRepository;
+    private final SettlementHistoryRepository settlementHistoryRepository;
     private final MemberRepository memberRepository;
 
     /**
@@ -53,6 +52,15 @@ public class SettlementService {
 
         settlement.setParticipants(participants);
         Settlement savedSettlement = settlementRepository.save(settlement);
+
+        SettlementHistory history = SettlementHistory.builder()
+                .settlement(savedSettlement)
+                .changedBy(payer)
+                .title(savedSettlement.getTitle())
+                .status(savedSettlement.getStatus())
+                .changedAt(LocalDateTime.now())
+                .build();
+        settlementHistoryRepository.save(history);
 
         return SettlementResponseDto.fromEntity(savedSettlement);
     }

--- a/src/test/java/com/zero/cohousesever/settlement/service/SettlementServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/settlement/service/SettlementServiceTest.java
@@ -1,0 +1,110 @@
+package com.zero.cohousesever.settlement.service;
+
+import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.repository.MemberRepository;
+import com.zero.cohousesever.settlement.entity.PaymentStatus;
+import com.zero.cohousesever.settlement.entity.Settlement;
+import com.zero.cohousesever.settlement.entity.SettlementParticipant;
+import com.zero.cohousesever.settlement.entity.SettlementStatus;
+import com.zero.cohousesever.settlement.repository.PaymentHistoryRepository;
+import com.zero.cohousesever.settlement.repository.SettlementParticipantRepository;
+import com.zero.cohousesever.settlement.repository.SettlementRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SettlementRepository settlementRepository;
+
+    @Mock
+    private SettlementParticipantRepository settlementParticipantRepository;
+
+    @Mock
+    private PaymentHistoryRepository paymentHistoryRepository;
+
+    @InjectMocks
+    private SettlementService settlementService;
+
+    @Test
+    @DisplayName("결제자일 때 정산 취소 시 참여자 상태와 히스토리 정상 변경")
+    void cancelSettlement_ByPayer_Success() {
+        Long payerId = 1L;
+        Long settlementId = 100L;
+
+        Member payer = Member.builder()
+                .name("박결제")
+                .build();
+        payer.setId(payerId);
+
+        Member member1 = Member.builder()
+                .name("김참여")
+                .build();
+        member1.setId(2L);
+
+        Member member2 = Member.builder()
+                .name("신참여")
+                .build();
+        member2.setId(3L);
+
+        SettlementParticipant participantPaid = SettlementParticipant.builder()
+                .member(payer)
+                .status(PaymentStatus.PAID)
+                .shareAmount(10000L)
+                .build();
+
+        SettlementParticipant participantPending = SettlementParticipant.builder()
+                .member(member1)
+                .status(PaymentStatus.PENDING)
+                .shareAmount(5000L)
+                .build();
+
+        Settlement settlement = Settlement.builder()
+                .payer(payer)
+                .status(SettlementStatus.PENDING)
+                .settlementParticipants(List.of(participantPaid, participantPending))
+                .build();
+        settlement.setId(settlementId);
+
+        // Mock 동작 정의
+        when(memberRepository.findById(payerId)).thenReturn(Optional.of(payer));
+        when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
+        when(settlementParticipantRepository.saveAll(anyList())).thenReturn(null); // void 대체
+        when(settlementRepository.save(any())).thenReturn(settlement);
+        when(paymentHistoryRepository.save(any())).thenAnswer(i -> i.getArgument(0)); // 저장한 객체 그대로 반환
+
+        // 실행
+        settlementService.cancelSettlement(payerId, settlementId);
+
+        // 검증
+        // 결제자는 PAID → REFUNDED 상태가 됨
+        assertEquals(PaymentStatus.REFUNDED, participantPaid.getStatus());
+
+        // 대기중인 참여자는 PENDING → CANCELED 상태가 됨
+        assertEquals(PaymentStatus.CANCELED, participantPending.getStatus());
+
+        // 정산 상태가 CANCELED로 변경되었는지 확인
+        assertEquals(SettlementStatus.CANCELED, settlement.getStatus());
+
+        // Repository 저장 호출 여부 검증
+        verify(settlementParticipantRepository, times(1)).saveAll(anyList());
+        verify(settlementRepository, times(1)).save(settlement);
+        verify(paymentHistoryRepository, atLeastOnce()).save(any());
+    }
+}

--- a/src/test/java/com/zero/cohousesever/settlement/service/SettlementServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/settlement/service/SettlementServiceTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.nio.file.AccessDeniedException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -139,25 +140,19 @@ class SettlementServiceTest {
     }
 
     @Test
-    @DisplayName("결제자일 때 정산 취소 시 참여자 상태와 히스토리 정상 변경")
+    @DisplayName("결제자일 때 정산 취소 시 참여자 상태와 히스토리 상태 'REFUNDED'로 변경")
     void cancelSettlement_ByPayer_Success() {
         Long payerId = 1L;
         Long settlementId = 100L;
 
-        Member payer = Member.builder().name("박결제").build();
-        ReflectionTestUtils.setField(payer, "id", payerId);
-
-        Member member1 = Member.builder().name("김참여").build();
-        ReflectionTestUtils.setField(member1, "id", 2L);
-
         SettlementParticipant participantPaid = SettlementParticipant.builder()
-                .member(payer)
+                .member(participant1)
                 .status(PaymentStatus.PAID)
                 .shareAmount(10000L)
                 .build();
 
         SettlementParticipant participantPending = SettlementParticipant.builder()
-                .member(member1)
+                .member(participant2)
                 .status(PaymentStatus.PENDING)
                 .shareAmount(5000L)
                 .build();
@@ -173,7 +168,7 @@ class SettlementServiceTest {
         when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
         when(settlementParticipantRepository.saveAll(anyList())).thenReturn(null);
         when(settlementRepository.save(any())).thenReturn(settlement);
-        when(paymentHistoryRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(paymentHistoryRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         settlementService.cancelSettlement(payerId, settlementId);
 
@@ -184,33 +179,33 @@ class SettlementServiceTest {
     }
 
     @Test
-    @DisplayName("송금 실패 시 예외 발생")
-    void transfer_Failure_ThrowsException() {
-        Long payerId = 1L;
+    @DisplayName("송금 처리 중 예외 발생 시 참여자와 PaymentHistory 상태가 FAILED로 변경됨")
+    void transfer_Exception_SetsFailedStatusForParticipant() throws AccessDeniedException {
         Long settlementId = 100L;
 
-        Member payer = Member.builder().name("Alice").build();
-        ReflectionTestUtils.setField(payer, "id", payerId);
+        SettlementParticipant participant = SettlementParticipant.builder()
+                .member(participant1)
+                .status(PaymentStatus.PENDING)
+                .shareAmount(10000L)
+                .build();
 
         Settlement settlement = Settlement.builder()
                 .payer(payer)
                 .status(SettlementStatus.PENDING)
-                .settlementParticipants(Collections.emptyList())
+                .settlementParticipants(List.of(participant))
                 .build();
         ReflectionTestUtils.setField(settlement, "id", settlementId);
 
-        when(memberRepository.findById(payerId)).thenReturn(Optional.of(payer));
+        when(memberRepository.findById(participant1.getId())).thenReturn(Optional.of(participant1));
         when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
 
-        doThrow(new CustomException(ErrorCode.PAYMENT_TRANSFER_FAILED))
-                .when(settlementParticipantRepository).saveAll(anyList());
+        // settlementParticipantRepository.save 호출 시 예외 발생
+        doThrow(new RuntimeException("DB 저장 실패"))
+                .when(settlementParticipantRepository).save(any());
 
-        CustomException exception = assertThrows(CustomException.class, () -> {
-            paymentService.processPayment(payerId, settlementId);
-        });
+        PaymentHistory paymentHistory = paymentService.processPayment(participant1.getId(), settlementId);
 
-//        then
-        assertEquals(ErrorCode.PAYMENT_TRANSFER_FAILED, exception.getErrorCode());
+        // try-catch 안에서 예외 발생 → catch 블록 수행
+        assertEquals(PaymentStatus.FAILED, paymentHistory.getStatus());
     }
-
 }

--- a/src/test/java/com/zero/cohousesever/settlement/service/SettlementServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/settlement/service/SettlementServiceTest.java
@@ -1,25 +1,34 @@
 package com.zero.cohousesever.settlement.service;
 
+import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.common.exception.ErrorCode;
+import com.zero.cohousesever.group.entity.Group;
+import com.zero.cohousesever.group.entity.GroupMember;
+import com.zero.cohousesever.group.enums.GroupMemberStatus;
+import com.zero.cohousesever.group.repository.GroupMemberRepository;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
-import com.zero.cohousesever.settlement.entity.PaymentStatus;
-import com.zero.cohousesever.settlement.entity.Settlement;
-import com.zero.cohousesever.settlement.entity.SettlementParticipant;
-import com.zero.cohousesever.settlement.entity.SettlementStatus;
+import com.zero.cohousesever.settlement.dto.CreateSettlementRequest;
+import com.zero.cohousesever.settlement.dto.SettlementResponseDto;
+import com.zero.cohousesever.settlement.entity.*;
 import com.zero.cohousesever.settlement.repository.PaymentHistoryRepository;
+import com.zero.cohousesever.settlement.repository.SettlementHistoryRepository;
 import com.zero.cohousesever.settlement.repository.SettlementParticipantRepository;
 import com.zero.cohousesever.settlement.repository.SettlementRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
@@ -31,6 +40,9 @@ class SettlementServiceTest {
     private MemberRepository memberRepository;
 
     @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @Mock
     private SettlementRepository settlementRepository;
 
     @Mock
@@ -39,8 +51,92 @@ class SettlementServiceTest {
     @Mock
     private PaymentHistoryRepository paymentHistoryRepository;
 
+    @Mock
+    private SettlementHistoryRepository settlementHistoryRepository;
+
     @InjectMocks
     private SettlementService settlementService;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    private Member payer;
+    private Member participant1;
+    private Member participant2;
+    private Group group;
+    private GroupMember activeGroupMember;
+
+    @BeforeEach
+    void setUp() {
+        payer = Member.builder().name("김민수").build();
+        ReflectionTestUtils.setField(payer, "id", 1L);
+
+        participant1 = Member.builder().name("박영희").build();
+        ReflectionTestUtils.setField(participant1, "id", 2L);
+
+        participant2 = Member.builder().name("이철수").build();
+        ReflectionTestUtils.setField(participant2, "id", 3L);
+
+        group = Group.builder().name("테스트 그룹").build();
+        ReflectionTestUtils.setField(group, "id", 1L);
+
+        activeGroupMember = GroupMember.builder()
+                .member(payer)
+                .group(group)
+                .status(GroupMemberStatus.ACTIVE)
+                .build();
+    }
+
+    @Test
+    @DisplayName("정산 생성 성공 - 균등 분배")
+    void createSettlement_Success_EqualDistribution() {
+        // Given
+        Long payerId = 1L;
+        CreateSettlementRequest request = CreateSettlementRequest.builder()
+                .title("Test Settlement")
+                .description("Test Description")
+                .category(SettlementCategory.CULTURE)
+                .settlementAmount(30000L)
+                .equalDistribution(true)
+                .participantIds(List.of(2L, 3L))
+                .build();
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(payer));
+        when(memberRepository.findById(2L)).thenReturn(Optional.of(participant1));
+        when(memberRepository.findById(3L)).thenReturn(Optional.of(participant2));
+        when(groupMemberRepository.findByMemberIdAndStatus(payerId, GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(activeGroupMember));
+        when(settlementRepository.save(any(Settlement.class))).thenAnswer(invocation -> {
+            Settlement settlement = invocation.getArgument(0);
+            ReflectionTestUtils.setField(settlement, "id", 1L);
+            return settlement;
+        });
+        when(settlementHistoryRepository.save(any(SettlementHistory.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        SettlementResponseDto responseDto = settlementService.createSettlement(payerId, request);
+
+        // Then
+        assertAll("정산 생성 결과 검증",
+                () -> assertEquals(request.getTitle(), responseDto.getTitle()),
+                () -> assertEquals(request.getDescription(), responseDto.getDescription()),
+                () -> assertEquals(request.getCategory(), responseDto.getCategory()),
+                () -> assertEquals(request.getSettlementAmount(), responseDto.getSettlementAmount()),
+                () -> assertEquals(SettlementStatus.PENDING, responseDto.getStatus()),
+                () -> assertEquals(payerId, responseDto.getPayerId()),
+                () -> assertEquals(3, responseDto.getParticipants().size()),
+                () -> assertTrue(responseDto.isEqualDistribution())
+        );
+
+        // 각 참여자의 분담금 검증 (30000 / 3 = 10000)
+        responseDto.getParticipants().forEach(participant -> {
+            assertEquals(10000L, participant.getShareAmount());
+        });
+
+        // 플랫폼 지원금 검증 (30000 % 3 = 0)
+        assertEquals(0L, responseDto.getPlatformSupportAmount());
+    }
 
     @Test
     @DisplayName("결제자일 때 정산 취소 시 참여자 상태와 히스토리 정상 변경")
@@ -48,20 +144,11 @@ class SettlementServiceTest {
         Long payerId = 1L;
         Long settlementId = 100L;
 
-        Member payer = Member.builder()
-                .name("박결제")
-                .build();
-        payer.setId(payerId);
+        Member payer = Member.builder().name("박결제").build();
+        ReflectionTestUtils.setField(payer, "id", payerId);
 
-        Member member1 = Member.builder()
-                .name("김참여")
-                .build();
-        member1.setId(2L);
-
-        Member member2 = Member.builder()
-                .name("신참여")
-                .build();
-        member2.setId(3L);
+        Member member1 = Member.builder().name("김참여").build();
+        ReflectionTestUtils.setField(member1, "id", 2L);
 
         SettlementParticipant participantPaid = SettlementParticipant.builder()
                 .member(payer)
@@ -80,31 +167,50 @@ class SettlementServiceTest {
                 .status(SettlementStatus.PENDING)
                 .settlementParticipants(List.of(participantPaid, participantPending))
                 .build();
-        settlement.setId(settlementId);
+        ReflectionTestUtils.setField(settlement, "id", settlementId);
 
-        // Mock 동작 정의
         when(memberRepository.findById(payerId)).thenReturn(Optional.of(payer));
         when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
-        when(settlementParticipantRepository.saveAll(anyList())).thenReturn(null); // void 대체
+        when(settlementParticipantRepository.saveAll(anyList())).thenReturn(null);
         when(settlementRepository.save(any())).thenReturn(settlement);
-        when(paymentHistoryRepository.save(any())).thenAnswer(i -> i.getArgument(0)); // 저장한 객체 그대로 반환
+        when(paymentHistoryRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
-        // 실행
         settlementService.cancelSettlement(payerId, settlementId);
 
-        // 검증
-        // 결제자는 PAID → REFUNDED 상태가 됨
+        // then
         assertEquals(PaymentStatus.REFUNDED, participantPaid.getStatus());
-
-        // 대기중인 참여자는 PENDING → CANCELED 상태가 됨
         assertEquals(PaymentStatus.CANCELED, participantPending.getStatus());
-
-        // 정산 상태가 CANCELED로 변경되었는지 확인
         assertEquals(SettlementStatus.CANCELED, settlement.getStatus());
-
-        // Repository 저장 호출 여부 검증
-        verify(settlementParticipantRepository, times(1)).saveAll(anyList());
-        verify(settlementRepository, times(1)).save(settlement);
-        verify(paymentHistoryRepository, atLeastOnce()).save(any());
     }
+
+    @Test
+    @DisplayName("송금 실패 시 예외 발생")
+    void transfer_Failure_ThrowsException() {
+        Long payerId = 1L;
+        Long settlementId = 100L;
+
+        Member payer = Member.builder().name("Alice").build();
+        ReflectionTestUtils.setField(payer, "id", payerId);
+
+        Settlement settlement = Settlement.builder()
+                .payer(payer)
+                .status(SettlementStatus.PENDING)
+                .settlementParticipants(Collections.emptyList())
+                .build();
+        ReflectionTestUtils.setField(settlement, "id", settlementId);
+
+        when(memberRepository.findById(payerId)).thenReturn(Optional.of(payer));
+        when(settlementRepository.findById(settlementId)).thenReturn(Optional.of(settlement));
+
+        doThrow(new CustomException(ErrorCode.PAYMENT_TRANSFER_FAILED))
+                .when(settlementParticipantRepository).saveAll(anyList());
+
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            paymentService.processPayment(payerId, settlementId);
+        });
+
+//        then
+        assertEquals(ErrorCode.PAYMENT_TRANSFER_FAILED, exception.getErrorCode());
+    }
+
 }


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
기능 추가
- processPayment 메서드 추가하여 참여자가 송금 버튼 클릭 시 상태를 PAID로 변경
- 정산 금액 균등 분배 시 발생하는 오차를 플랫폼이 부담하는 기능 추가
- 정산 취소 시 참여자 상태 및 송금 내역 상태를 연동해 환불 처리 기능 구현

리팩토링 
- 송금 히스토리 엔티티 필드명 payer → sender, payee → receiver로 변경
- 직접 분배 방식의 정산 금액 요청 시, 참가자와 각 송금할 금액을 Map 데이터로 수정
- 균등·직접 분배 참여자 생성 메서드 분리
---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
- 플랫폼이 부담하는 오차 금액(platformSupportAmount) 컬럼 추가

- 균등 분배 시 금액 나누어떨어지지 않는 경우 플랫폼이 자동으로 오차 금액을 처리하도록 수정

ex. 오차 금액을 처리 예시 

총 금액(M) | 참여자 수(N) | 1인 부담액(몫) | 플랫폼 부담(나머지)
-- | -- | -- | --
10,000원 | 3명 | 3,333원 | 1원
10,000원 | 4명 | 2,500원 | 0원
10,000원 | 6명 | 1,666원 | 4원

- 사용자가 직접 금액을 입력하는 직접 분배 기능 개발

- 직접 분배 방식의 정산 금액 요청 시, 참여자 ID를 키 : 분배 금액을 값으로 하는 Map 데이터로 수정

- 송금 히스토리(PaymentHistory) 내 필드명 변경으로 송금자(sender)와 수취자(receiver)를 명확히 구분

- 송금 완료 처리 시 참여자 상태를 자동으로 PAID로 업데이트

- 균등·직접 분배 참여자 생성 메서드 분리 및 리팩토링

- 정산 취소 시 참여자 상태 및 송금 내역 상태를 연동해 환불 처리 기능 구현
---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->

---

## Reason
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->
- 정산금액 균등 분배 시 오차 부담을 자동화해 사용자 편의성을 높이고, 정산 예외 상황 최소화

- 자동 분배, 직접 분배 기능을 분리하므로 유지보수성 용이

- 명확한 용어 사용으로 유지보수성 및 코드 가독성 향상

- 참여자 상태 자동 업데이트로 송금 완료 여부 추적 용이

- cancelSettlement 메서드에 @Transactional을 쓴 이유

  - 만약 중간에 어느 한 작업이라도 실패하면 전체 데이터 상태가 불일치할 위험이 있습니다.

  - 처음에는 try-catch로 오류 처리하고 상태 복구를 시도하려 했으나, 복구 과정에서 또 다른 예외가 발생할 경우 데이터 무결성이 깨질 수 있다고 판단했습니다.

  - 따라서 여러 작업을 하나의 트랜잭션으로 묶어 처리하는 @Transactional 방식을 적용하여,  
    작업 중 오류 발생 시 모든 변경사항을 자동으로 롤백해 일관성 있는 상태를 보장하도록 구현하였습니다.
---

## Work Done
<!-- 구체적인 작업 내역 -->
- [platformSupportAmount 필드 및 관련 로직 추가

- 균등 분배 금액 계산 및 오차 처리 코드 수정

- 직접 분배 금액 입력 및 검증 기능 구현

- PaymentHistory 엔티티 필드명 payer, payee → sender, receiver 변경

- processPayment 메서드 추가 및 송금 완료 시 참여자 상태 PAID로 변경 처리

- 정산 취소 시 참여자 상태 및 송금 내역 상태 연동 환불 처리 기능 구현
---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->
정산 생성 성공 - 균등 분배

- createSettlement() 호출 시 참여자별 균등 분담금 계산 및 Settlement 기본 정보 검증

- 플랫폼 지원금, Payer, 상태, 참여자 수 등 검증

결제자에 의한 정산 취소 처리

- cancelSettlement() 호출 시 결제자와 참여자 상태가 올바르게 REFUNDED / CANCELED로 변경되는지 검증

- Settlement 상태가 CANCELED로 변경되는지 확인

송금 처리 중 예외 발생 시 실패 처리

- processPayment() 호출 시 settlementParticipantRepository.save()에서 예외 발생 시 PaymentHistory 상태가 FAILED로 변경되는지 검증
---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->
주요 기능인 정산 등록, 정산 취소, 송금 완료 처리 로직에 집중해서 리뷰를 부탁드립니다.
---

## Issue
Closes #52 #55 
