### PR TITLE
Feature: #49 로그인 리프레시 기능 구현

### DIFF
--- a/src/main/java/com/zero/cohousesever/common/config/RedisConfig.java
+++ b/src/main/java/com/zero/cohousesever/common/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.zero.cohousesever.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/zero/cohousesever/common/config/RedisConfig.java
+++ b/src/main/java/com/zero/cohousesever/common/config/RedisConfig.java
@@ -1,24 +1,10 @@
 package com.zero.cohousesever.common.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig {
 
-    @Bean
-    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-
-        return template;
-    }
 }

--- a/src/main/java/com/zero/cohousesever/member/controller/AuthController.java
+++ b/src/main/java/com/zero/cohousesever/member/controller/AuthController.java
@@ -2,10 +2,12 @@ package com.zero.cohousesever.member.controller;
 
 import com.zero.cohousesever.member.dto.MessageDto;
 import com.zero.cohousesever.member.dto.auth.*;
+import com.zero.cohousesever.member.security.CustomUserDetails;
 import com.zero.cohousesever.member.service.AuthService;
 import com.zero.cohousesever.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -84,10 +86,12 @@ public class AuthController {
     // 리프레시 토큰을 통한 액세스 토큰 재발급
     @PostMapping("/login/refresh")
     public ResponseEntity<JwtTokenResponseDto> refreshAccessToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody RefreshRequestDto requestDto
     ) {
+        JwtTokenResponseDto responseDto = authService.reissueAccessToken(userDetails, requestDto);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(responseDto);
     }
 
     // 회원 탈퇴

--- a/src/main/java/com/zero/cohousesever/member/enums/TokenValidationStatus.java
+++ b/src/main/java/com/zero/cohousesever/member/enums/TokenValidationStatus.java
@@ -1,4 +1,4 @@
-package com.zero.cohousesever.member.security;
+package com.zero.cohousesever.member.enums;
 
 public enum TokenValidationStatus {
     VALID,

--- a/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
@@ -6,11 +6,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -25,7 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final UserDetailsService userDetailsService;
+    private final CustomUserDetailsService userDetailsService;
 
     @Override
     protected void doFilterInternal(
@@ -38,28 +36,27 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token)) {
             TokenValidationStatus status = jwtTokenProvider.validateToken(token);
 
-            switch (status) {
-                case VALID -> {
-                    try {
-                        String email = jwtTokenProvider.getEmailFromToken(token);
-                        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-                        UsernamePasswordAuthenticationToken authentication =
-                                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                        SecurityContextHolder.getContext().setAuthentication(authentication);
-                    } catch (RuntimeException e) { // TODO: userDetailsService.loadUserByUsername()에서 던지는 예외를 캐치하도록 변경
-                        // 사용자를 찾지 못하면 인증 실패 처리
-                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
-                        return;
-                    }
-                }
-                case EXPIRED -> {
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
+            if (status == TokenValidationStatus.VALID ||
+                    (status == TokenValidationStatus.EXPIRED && request.getRequestURI().equals("/members/login/refresh"))) {
+                try {
+                    String email = jwtTokenProvider.getEmailFromToken(token);
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } catch (RuntimeException e) {
+                    // TODO: CustomUserDetailsService에서 던지는 예외 받기
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                     return;
                 }
-                case INVALID -> {
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
-                    return;
-                }
+            } else if (status == TokenValidationStatus.EXPIRED) {
+                // TODO: 토큰 만료 예외 작성
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            } else if (status == TokenValidationStatus.INVALID) {
+                // TODO: 토큰 무효 예외 작성
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
             }
         }
 

--- a/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -33,29 +34,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
         String token = resolveToken(request);
-        TokenValidationStatus status = jwtTokenProvider.validateToken(token);
 
-        switch (status) {
-            case VALID -> {
-                try {
-                    String email = jwtTokenProvider.getEmailFromToken(token);
-                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                } catch (RuntimeException e) { // TODO: userDetailsService.loadUserByUsername()에서 던지는 예외를 캐치하도록 변경
-                    // 사용자를 찾지 못하면 인증 실패 처리
+        if (StringUtils.hasText(token)) {
+            TokenValidationStatus status = jwtTokenProvider.validateToken(token);
+
+            switch (status) {
+                case VALID -> {
+                    try {
+                        String email = jwtTokenProvider.getEmailFromToken(token);
+                        UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                        UsernamePasswordAuthenticationToken authentication =
+                                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                        SecurityContextHolder.getContext().setAuthentication(authentication);
+                    } catch (RuntimeException e) { // TODO: userDetailsService.loadUserByUsername()에서 던지는 예외를 캐치하도록 변경
+                        // 사용자를 찾지 못하면 인증 실패 처리
+                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
+                        return;
+                    }
+                }
+                case EXPIRED -> {
                     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
                     return;
                 }
-            }
-            case EXPIRED -> {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
-                return;
-            }
-            case INVALID -> {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
-                return;
+                case INVALID -> {
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
+                    return;
+                }
             }
         }
 

--- a/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.member.security;
 
+import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
@@ -32,7 +32,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletResponse response,
             FilterChain filterChain
     ) throws ServletException, IOException {
-
         String token = resolveToken(request);
         TokenValidationStatus status = jwtTokenProvider.validateToken(token);
 
@@ -46,7 +45,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     SecurityContextHolder.getContext().setAuthentication(authentication);
                 } catch (RuntimeException e) { // TODO: userDetailsService.loadUserByUsername()에서 던지는 예외를 캐치하도록 변경
                     // 사용자를 찾지 못하면 인증 실패 처리
-                    SecurityContextHolder.clearContext();
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
+                    return;
                 }
             }
             case EXPIRED -> {

--- a/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
@@ -33,19 +33,29 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         String token = resolveToken(request);
+        TokenValidationStatus status = jwtTokenProvider.validateToken(token);
 
-
-        try {
-            if (jwtTokenProvider.validateToken(token)) {
-                String email = jwtTokenProvider.getEmailFromToken(token);
-                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+        switch (status) {
+            case VALID -> {
+                try {
+                    String email = jwtTokenProvider.getEmailFromToken(token);
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } catch (RuntimeException e) { // TODO: userDetailsService.loadUserByUsername()에서 던지는 예외를 캐치하도록 변경
+                    // 사용자를 찾지 못하면 인증 실패 처리
+                    SecurityContextHolder.clearContext();
+                }
             }
-        } catch (RuntimeException e) { // TODO: userDetailsService.loadUserByUsername()에서 던지는 예외를 캐치하도록 변경
-            // 사용자를 찾지 못하면 인증 실패 처리
-            SecurityContextHolder.clearContext();
+            case EXPIRED -> {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
+                return;
+            }
+            case INVALID -> {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // TODO: 적절한 예외 구현하기
+                return;
+            }
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/zero/cohousesever/member/security/JwtTokenProvider.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtTokenProvider.java
@@ -1,14 +1,10 @@
 package com.zero.cohousesever.member.security;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
@@ -59,27 +55,32 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public boolean validateToken(String token) {
-        if (!StringUtils.hasText(token)) {
-            return false;
+    public TokenValidationStatus validateToken(String token) {
+        try {
+            parseClaims(token);
+            return TokenValidationStatus.VALID;
+        } catch (ExpiredJwtException e) {
+            return TokenValidationStatus.EXPIRED;
+        } catch (JwtException | IllegalArgumentException e) {
+            return TokenValidationStatus.INVALID;
         }
-
-        Claims claims = parseClaims(token);
-        return !claims.getExpiration().before(new Date());
     }
 
     private Claims parseClaims(String token) {
         SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes());
         JwtParser parser = Jwts.parser().verifyWith(secretKey).build();
 
-        try {
-            return parser.parseSignedClaims(token).getPayload();
-        } catch (ExpiredJwtException e) {
-            return e.getClaims();
-        }
+        return parser.parseSignedClaims(token).getPayload();
     }
 
+    // 유효하지 않은 토큰인 경우 null 반환
     public String getEmailFromToken(String token) {
-        return parseClaims(token).get(KEY_EMAIL, String.class);
+        try {
+            return parseClaims(token).get(KEY_EMAIL, String.class);
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().get(KEY_EMAIL, String.class);
+        } catch (JwtException | IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/zero/cohousesever/member/security/JwtTokenProvider.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.member.security;
 
+import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/zero/cohousesever/member/security/JwtTokenProvider.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtTokenProvider.java
@@ -20,10 +20,10 @@ public class JwtTokenProvider {
     public static final String KEY_NAME = "name";
 
 
-    // TODO: 외부에서 이슈어, 비밀키 설정하기. 비밀키는 BASE64 인코딩된 문자열 사용
-    @Value("")
+    // 설정에서 이슈어, 비밀키 설정하기. 비밀키는 BASE64 인코딩된 문자열 사용
+    @Value("${jwt.issuer}")
     private String issuer;
-    @Value("")
+    @Value("${jwt.secret}")
     private String secret;
 
     public String generateAccessToken(String email, String name) {

--- a/src/main/java/com/zero/cohousesever/member/security/TokenValidationStatus.java
+++ b/src/main/java/com/zero/cohousesever/member/security/TokenValidationStatus.java
@@ -1,0 +1,7 @@
+package com.zero.cohousesever.member.security;
+
+public enum TokenValidationStatus {
+    VALID,
+    INVALID,
+    EXPIRED
+}

--- a/src/main/java/com/zero/cohousesever/member/service/AuthService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/AuthService.java
@@ -2,10 +2,13 @@ package com.zero.cohousesever.member.service;
 
 import com.zero.cohousesever.member.dto.auth.JwtTokenResponseDto;
 import com.zero.cohousesever.member.dto.auth.LoginRequestDto;
+import com.zero.cohousesever.member.dto.auth.RefreshRequestDto;
 import com.zero.cohousesever.member.dto.auth.SignupRequestDto;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
+import com.zero.cohousesever.member.security.CustomUserDetails;
 import com.zero.cohousesever.member.security.JwtTokenProvider;
+import com.zero.cohousesever.member.security.TokenValidationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ import java.util.Objects;
 public class AuthService {
 
     private final MemberService memberService;
+    private final RefreshTokenService refreshTokenService;
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
@@ -57,7 +61,9 @@ public class AuthService {
         }
 
         String accessToken = jwtTokenProvider.generateAccessToken(member.getEmail(), member.getName());
-        String refreshToken = jwtTokenProvider.generateRefreshToken(); // TODO: Redis 서버에 리프레시토큰 저장
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+        // 리프레시 토큰은 redis에 저장
+        refreshTokenService.saveRefreshToken(member.getId(), refreshToken, JwtTokenProvider.REFRESH_TOKEN_EXPIRATION_TIME);
 
         return JwtTokenResponseDto.builder()
                 .accessToken(accessToken)
@@ -67,5 +73,29 @@ public class AuthService {
 
     public boolean isEmailDuplicated(String email) {
         return memberRepository.existsByEmail(email);
+    }
+
+    public JwtTokenResponseDto reissueAccessToken(CustomUserDetails userDetails, RefreshRequestDto requestDto) {
+        String memberRefreshToken = requestDto.getRefreshToken();
+        String serverRefreshToken = refreshTokenService.getRefreshToken(userDetails.getId());
+
+        if (!jwtTokenProvider.validateToken(memberRefreshToken).equals(TokenValidationStatus.VALID)) {
+            throw new RuntimeException(); // TODO: '유효하지 않은 리프레시 토큰입니다' 예외 작성
+        }
+
+        if (!jwtTokenProvider.validateToken(serverRefreshToken).equals(TokenValidationStatus.VALID)) {
+            throw new RuntimeException(); // TODO: '리프레시 토큰이 만료되었습니다.' 예외 작성
+        }
+
+        if (!Objects.equals(memberRefreshToken, serverRefreshToken)) {
+            throw new RuntimeException(); // TODO: '유효하지 않은 리프레시 토큰입니다' 예외 작성
+        }
+
+        String newAccessToken = jwtTokenProvider.generateAccessToken(userDetails.getEmail(), userDetails.getName());
+
+        return JwtTokenResponseDto.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(serverRefreshToken)
+                .build();
     }
 }

--- a/src/main/java/com/zero/cohousesever/member/service/AuthService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/AuthService.java
@@ -8,7 +8,7 @@ import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.member.security.CustomUserDetails;
 import com.zero.cohousesever.member.security.JwtTokenProvider;
-import com.zero.cohousesever.member.security.TokenValidationStatus;
+import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/zero/cohousesever/member/service/RefreshTokenService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/RefreshTokenService.java
@@ -1,0 +1,35 @@
+package com.zero.cohousesever.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "RT:";
+
+    private final RedisTemplate<String, String> stringRedisTemplate;
+
+    public void saveRefreshToken(Long memberId, String refreshToken, long expirationMillis) {
+        // "RT:{memberId}" 형태로 키 저장
+        String key = REFRESH_TOKEN_KEY_PREFIX + memberId;
+
+        stringRedisTemplate.opsForValue().set(key, refreshToken, expirationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    public String getRefreshToken(Long memberId) {
+        String key = REFRESH_TOKEN_KEY_PREFIX + memberId;
+
+        return stringRedisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteRefreshToken(Long memberId) {
+        String key = REFRESH_TOKEN_KEY_PREFIX + memberId;
+
+        stringRedisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/cohouse_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: root
-    password: rootroot
+    password: 1
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/cohouse_db?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: root
-    password: 1
+    password: rootroot
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
@@ -15,3 +15,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+jwt:
+  secret: Y29ob3VzZXByb2plY3Rzand0c2VjcmV0c3RyaW5nc3dpdGhiYXNlNjRlbmNvZGluZ3M=
+  issuer: cohouse

--- a/src/test/java/com/zero/cohousesever/member/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/zero/cohousesever/member/security/JwtAuthenticationFilterTest.java
@@ -2,6 +2,7 @@ package com.zero.cohousesever.member.security;
 
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.enums.MemberStatus;
+import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import jakarta.servlet.ServletException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -57,7 +58,7 @@ class JwtAuthenticationFilterTest {
 
         request.addHeader("Authorization", "Bearer " + validToken);
 
-        when(jwtTokenProvider.validateToken(validToken)).thenReturn(true);
+        when(jwtTokenProvider.validateToken(validToken)).thenReturn(TokenValidationStatus.VALID);
         when(jwtTokenProvider.getEmailFromToken(validToken)).thenReturn(email);
         when(customUserDetailsService.loadUserByUsername(email)).thenReturn(userDetails);
 
@@ -72,6 +73,33 @@ class JwtAuthenticationFilterTest {
         // SecurityContext에 인증 정보가 설정되었는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
         assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(userDetails);
+        
+        // 필터 체인이 정상적으로 실행되었는지 확인
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("만료된 JWT 토큰으로 인증 실패")
+    void shouldNotAuthenticateWithExpiredJwtToken() throws ServletException, IOException {
+        // given
+        String expiredToken = "expired.jwt.token";
+        request.addHeader("Authorization", "Bearer " + expiredToken);
+
+        when(jwtTokenProvider.validateToken(expiredToken)).thenReturn(TokenValidationStatus.EXPIRED);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(jwtTokenProvider).validateToken(expiredToken);
+        verify(jwtTokenProvider, never()).getEmailFromToken(anyString());
+        verify(customUserDetailsService, never()).loadUserByUsername(anyString());
+
+        // 401 Unauthorized 응답 확인
+        assertThat(response.getStatus()).isEqualTo(401);
+        
+        // SecurityContext에 인증 정보가 설정되지 않았는지 확인
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 
     @Test
@@ -81,7 +109,7 @@ class JwtAuthenticationFilterTest {
         String invalidToken = "invalid.jwt.token";
         request.addHeader("Authorization", "Bearer " + invalidToken);
 
-        when(jwtTokenProvider.validateToken(invalidToken)).thenReturn(false);
+        when(jwtTokenProvider.validateToken(invalidToken)).thenReturn(TokenValidationStatus.INVALID);
 
         // when
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -91,23 +119,29 @@ class JwtAuthenticationFilterTest {
         verify(jwtTokenProvider, never()).getEmailFromToken(anyString());
         verify(customUserDetailsService, never()).loadUserByUsername(anyString());
 
+        // 401 Unauthorized 응답 확인
+        assertThat(response.getStatus()).isEqualTo(401);
+        
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 
     @Test
-    @DisplayName("JWT 토큰이 없는 경우 필터 체인만 실행")
+    @DisplayName("JWT 토큰이 없는 경우 인증 실패")
     void shouldContinueFilterChainWhenNoJwtToken() throws ServletException, IOException {
         // given
         // Authorization 헤더 없음
+        when(jwtTokenProvider.validateToken(null)).thenReturn(TokenValidationStatus.INVALID);
 
         // when
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
         // then
-        verify(jwtTokenProvider, never()).validateToken(anyString());
         verify(jwtTokenProvider, never()).getEmailFromToken(anyString());
         verify(customUserDetailsService, never()).loadUserByUsername(anyString());
+
+        // 401 Unauthorized 응답 확인
+        assertThat(response.getStatus()).isEqualTo(401);
 
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
@@ -118,32 +152,17 @@ class JwtAuthenticationFilterTest {
     void shouldHandleMalformedAuthorizationHeader() throws ServletException, IOException {
         // given
         request.addHeader("Authorization", "InvalidFormat");
+        when(jwtTokenProvider.validateToken(null)).thenReturn(TokenValidationStatus.INVALID);
 
         // when
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
         // then
-        verify(jwtTokenProvider, never()).validateToken(anyString());
         verify(jwtTokenProvider, never()).getEmailFromToken(anyString());
         verify(customUserDetailsService, never()).loadUserByUsername(anyString());
 
-        // SecurityContext에 인증 정보가 설정되지 않았는지 확인
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-    }
-
-    @Test
-    @DisplayName("Bearer 접두사가 없는 경우")
-    void shouldHandleMissingBearerPrefix() throws ServletException, IOException {
-        // given
-        request.addHeader("Authorization", "valid.jwt.token");
-
-        // when
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        verify(jwtTokenProvider, never()).validateToken(anyString());
-        verify(jwtTokenProvider, never()).getEmailFromToken(anyString());
-        verify(customUserDetailsService, never()).loadUserByUsername(anyString());
+        // 401 Unauthorized 응답 확인
+        assertThat(response.getStatus()).isEqualTo(401);
 
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
@@ -158,7 +177,7 @@ class JwtAuthenticationFilterTest {
 
         request.addHeader("Authorization", "Bearer " + validToken);
 
-        when(jwtTokenProvider.validateToken(validToken)).thenReturn(true);
+        when(jwtTokenProvider.validateToken(validToken)).thenReturn(TokenValidationStatus.VALID);
         when(jwtTokenProvider.getEmailFromToken(validToken)).thenReturn(email);
         when(customUserDetailsService.loadUserByUsername(email))
                 .thenThrow(new RuntimeException("User not found"));
@@ -171,23 +190,11 @@ class JwtAuthenticationFilterTest {
         verify(jwtTokenProvider).getEmailFromToken(validToken);
         verify(customUserDetailsService).loadUserByUsername(email);
 
+        // 401 Unauthorized 응답 확인
+        assertThat(response.getStatus()).isEqualTo(401);
+        
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
-    }
-
-    @Test
-    @DisplayName("필터 체인이 정상적으로 실행되는지 확인")
-    void shouldContinueFilterChain() throws ServletException, IOException {
-        // given
-        // JWT 토큰 없음
-
-        // when
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
-
-        // then
-        // 필터 체인이 정상적으로 실행되었는지 확인
-        // MockFilterChain은 실제로는 아무것도 하지 않지만, 예외가 발생하지 않아야 함
-        assertThat(response.getStatus()).isEqualTo(200);
     }
 
     // 테스트용 멤버 엔티티 생성

--- a/src/test/java/com/zero/cohousesever/member/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/zero/cohousesever/member/security/JwtAuthenticationFilterTest.java
@@ -70,12 +70,12 @@ class JwtAuthenticationFilterTest {
         verify(jwtTokenProvider).getEmailFromToken(validToken);
         verify(customUserDetailsService).loadUserByUsername(email);
 
+        // 필터 체인이 정상적으로 실행되었는지 확인
+        assertThat(response.getStatus()).isEqualTo(200);
+
         // SecurityContext에 인증 정보가 설정되었는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
         assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(userDetails);
-        
-        // 필터 체인이 정상적으로 실행되었는지 확인
-        assertThat(response.getStatus()).isEqualTo(200);
     }
 
     @Test
@@ -97,9 +97,41 @@ class JwtAuthenticationFilterTest {
 
         // 401 Unauthorized 응답 확인
         assertThat(response.getStatus()).isEqualTo(401);
-        
+
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("refresh 엔드포인트는 만료된 토큰도 인증을 통과")
+    void shouldAuthenticateWithExpiredJwtTokenForRefreshEndpoint() throws ServletException, IOException {
+        // given
+        String expiredToken = "expired.jwt.token";
+        String email = "test@example.com";
+        request.addHeader("Authorization", "Bearer " + expiredToken);
+        request.setRequestURI("/members/login/refresh");
+
+        Member member = createTestMember();
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+
+        when(jwtTokenProvider.validateToken(expiredToken)).thenReturn(TokenValidationStatus.EXPIRED);
+        when(jwtTokenProvider.getEmailFromToken(expiredToken)).thenReturn(email);
+        when(customUserDetailsService.loadUserByUsername(email)).thenReturn(userDetails);
+
+        // when
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(jwtTokenProvider).validateToken(expiredToken);
+        verify(jwtTokenProvider).getEmailFromToken(expiredToken);
+        verify(customUserDetailsService).loadUserByUsername(email);
+
+        // 필터 체인이 정상적으로 실행되었는지 확인
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        // SecurityContext에 인증 정보가 설정되었는지 확인
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(userDetails);
     }
 
     @Test
@@ -121,48 +153,48 @@ class JwtAuthenticationFilterTest {
 
         // 401 Unauthorized 응답 확인
         assertThat(response.getStatus()).isEqualTo(401);
-        
+
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 
     @Test
-    @DisplayName("JWT 토큰이 없는 경우 인증 실패")
+    @DisplayName("JWT 토큰이 없는 경우 필터 통과")
     void shouldContinueFilterChainWhenNoJwtToken() throws ServletException, IOException {
         // given
         // Authorization 헤더 없음
-        when(jwtTokenProvider.validateToken(null)).thenReturn(TokenValidationStatus.INVALID);
 
         // when
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
         // then
+        verify(jwtTokenProvider, never()).validateToken(anyString());
         verify(jwtTokenProvider, never()).getEmailFromToken(anyString());
         verify(customUserDetailsService, never()).loadUserByUsername(anyString());
 
-        // 401 Unauthorized 응답 확인
-        assertThat(response.getStatus()).isEqualTo(401);
+        // 정상 응답 확인
+        assertThat(response.getStatus()).isEqualTo(200);
 
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
 
     @Test
-    @DisplayName("잘못된 형식의 Authorization 헤더")
-    void shouldHandleMalformedAuthorizationHeader() throws ServletException, IOException {
+    @DisplayName("잘못된 형식의 Authorization 헤더는 인증하지 않고 통과")
+    void shouldPassMalformedAuthorizationHeader() throws ServletException, IOException {
         // given
         request.addHeader("Authorization", "InvalidFormat");
-        when(jwtTokenProvider.validateToken(null)).thenReturn(TokenValidationStatus.INVALID);
 
         // when
         jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
         // then
+        verify(jwtTokenProvider, never()).validateToken(anyString());
         verify(jwtTokenProvider, never()).getEmailFromToken(anyString());
         verify(customUserDetailsService, never()).loadUserByUsername(anyString());
 
         // 401 Unauthorized 응답 확인
-        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getStatus()).isEqualTo(200);
 
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
@@ -192,7 +224,7 @@ class JwtAuthenticationFilterTest {
 
         // 401 Unauthorized 응답 확인
         assertThat(response.getStatus()).isEqualTo(401);
-        
+
         // SecurityContext에 인증 정보가 설정되지 않았는지 확인
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }

--- a/src/test/java/com/zero/cohousesever/member/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/zero/cohousesever/member/security/JwtTokenProviderTest.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.member.security;
 
+import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtParser;
@@ -46,7 +47,7 @@ class JwtTokenProviderTest {
         // 토큰 유효성 검증
         assertThat(jwtTokenProvider.getEmailFromToken(token)).isEqualTo(email);
         assertThat(getNameFromToken(token)).isEqualTo(name);
-        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+        assertThat(jwtTokenProvider.validateToken(token)).isEqualTo(TokenValidationStatus.VALID);
     }
 
     @Test
@@ -60,7 +61,7 @@ class JwtTokenProviderTest {
         assertThat(token).isNotEmpty();
 
         // 토큰 유효성 검증
-        assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+        assertThat(jwtTokenProvider.validateToken(token)).isEqualTo(TokenValidationStatus.VALID);
     }
 
     @Test
@@ -70,10 +71,10 @@ class JwtTokenProviderTest {
         String emptyToken = "";
 
         // when
-        boolean isValid = jwtTokenProvider.validateToken(emptyToken);
+        TokenValidationStatus isValid = jwtTokenProvider.validateToken(emptyToken);
 
         // then
-        assertThat(isValid).isFalse();
+        assertThat(isValid).isEqualTo(TokenValidationStatus.INVALID);
     }
 
     @Test
@@ -83,10 +84,10 @@ class JwtTokenProviderTest {
         String nullToken = null;
 
         // when
-        boolean isValid = jwtTokenProvider.validateToken(nullToken);
+        TokenValidationStatus isValid = jwtTokenProvider.validateToken(nullToken);
 
         // then
-        assertThat(isValid).isFalse();
+        assertThat(isValid).isEqualTo(TokenValidationStatus.INVALID);
     }
 
     @Test
@@ -98,10 +99,25 @@ class JwtTokenProviderTest {
         String expiredToken = generateExpiredToken(email, name);
 
         // when
-        boolean isValid = jwtTokenProvider.validateToken(expiredToken);
+        TokenValidationStatus isValid = jwtTokenProvider.validateToken(expiredToken);
 
         // then
-        assertThat(isValid).isFalse();
+        assertThat(isValid).isEqualTo(TokenValidationStatus.EXPIRED);
+    }
+
+    @Test
+    @DisplayName("다른 키로 서명된 토큰 검증 실패")
+    void shouldFailValidationForInvalidSecretKeyToken() {
+        // given
+        String email = "test@example.com";
+        String name = "테스트 사용자";
+        String invalidSecretKeyToken = generateInvalidSecretKeyToken(email, name);
+
+        // when
+        TokenValidationStatus isValid = jwtTokenProvider.validateToken(invalidSecretKeyToken);
+
+        // then
+        assertThat(isValid).isEqualTo(TokenValidationStatus.INVALID);
     }
 
     /**
@@ -114,6 +130,24 @@ class JwtTokenProviderTest {
         Date now = new Date();
         // 만료 시간을 현재보다 과거로 설정 (예: 1초 전)
         Date expiration = new Date(now.getTime() - 1000);
+
+        return Jwts.builder()
+                .issuer(issuer)
+                .claims()
+                .add("email", email)
+                .add("name", name)
+                .and()
+                .issuedAt(now)
+                .expiration(expiration)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 다른 키로 토큰을 생성하는 메서드
+    private String generateInvalidSecretKeyToken(String email, String name) {
+        SecretKey secretKey = Keys.hmacShaKeyFor((secret+"test").getBytes());
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + 1000_000);
 
         return Jwts.builder()
                 .issuer(issuer)

--- a/src/test/java/com/zero/cohousesever/member/service/AuthServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/member/service/AuthServiceTest.java
@@ -2,10 +2,13 @@ package com.zero.cohousesever.member.service;
 
 import com.zero.cohousesever.member.dto.auth.JwtTokenResponseDto;
 import com.zero.cohousesever.member.dto.auth.LoginRequestDto;
+import com.zero.cohousesever.member.dto.auth.RefreshRequestDto;
 import com.zero.cohousesever.member.dto.auth.SignupRequestDto;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.enums.MemberStatus;
+import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import com.zero.cohousesever.member.repository.MemberRepository;
+import com.zero.cohousesever.member.security.CustomUserDetails;
 import com.zero.cohousesever.member.security.JwtTokenProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +34,9 @@ class AuthServiceTest {
     private MemberService memberService;
 
     @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
     private MemberRepository memberRepository;
 
     @Mock
@@ -45,6 +51,8 @@ class AuthServiceTest {
     private Member testMember;
     private SignupRequestDto signupRequestDto;
     private LoginRequestDto loginRequestDto;
+    private CustomUserDetails testUserDetails;
+    private RefreshRequestDto refreshRequestDto;
 
     @BeforeEach
     void setUp() {
@@ -68,6 +76,13 @@ class AuthServiceTest {
         loginRequestDto = new LoginRequestDto();
         ReflectionTestUtils.setField(loginRequestDto, "email", "test@example.com");
         ReflectionTestUtils.setField(loginRequestDto, "password", "password123");
+
+        // CustomUserDetails
+        testUserDetails = new CustomUserDetails(testMember);
+
+        // 토큰 리프레시 요청 DTO
+        refreshRequestDto = new RefreshRequestDto();
+        ReflectionTestUtils.setField(refreshRequestDto, "refreshToken", "validRefreshToken");
     }
 
     @Test
@@ -207,5 +222,105 @@ class AuthServiceTest {
         // then
         assertThat(result).isTrue();
         verify(memberRepository).existsByEmail("existing@example.com");
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 성공 - 유효한 리프레시 토큰으로 재발급")
+    void reissueAccessToken_Success() {
+        // given
+        String serverRefreshToken = "validRefreshToken";
+        String newAccessToken = "newAccessToken";
+        
+        when(refreshTokenService.getRefreshToken(anyLong())).thenReturn(serverRefreshToken);
+        when(jwtTokenProvider.validateToken(anyString())).thenReturn(TokenValidationStatus.VALID);
+        when(jwtTokenProvider.generateAccessToken(anyString(), anyString())).thenReturn(newAccessToken);
+
+        // when
+        JwtTokenResponseDto result = authService.reissueAccessToken(testUserDetails, refreshRequestDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getAccessToken()).isEqualTo(newAccessToken);
+        assertThat(result.getRefreshToken()).isEqualTo(serverRefreshToken);
+
+        verify(refreshTokenService).getRefreshToken(1L);
+        verify(jwtTokenProvider, times(2)).validateToken("validRefreshToken");
+        verify(jwtTokenProvider).generateAccessToken("test@example.com", "테스트유저");
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 실패 - 클라이언트 리프레시 토큰이 유효하지 않음")
+    void reissueAccessToken_Failure_InvalidClientRefreshToken() {
+        // given
+        when(jwtTokenProvider.validateToken("validRefreshToken")).thenReturn(TokenValidationStatus.INVALID);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueAccessToken(testUserDetails, refreshRequestDto))
+                .isInstanceOf(RuntimeException.class); // TODO: '유효하지 않은 리프레시 토큰입니다' 예외 작성 후 메시지 검증 추가
+
+        verify(jwtTokenProvider).validateToken("validRefreshToken");
+        verify(jwtTokenProvider, never()).generateAccessToken(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 실패 - 서버 리프레시 토큰이 만료됨")
+    void reissueAccessToken_Failure_ExpiredServerRefreshToken() {
+        // given
+        String serverRefreshToken = "expiredRefreshToken";
+        
+        when(refreshTokenService.getRefreshToken(anyLong())).thenReturn(serverRefreshToken);
+        when(jwtTokenProvider.validateToken("validRefreshToken")).thenReturn(TokenValidationStatus.VALID);
+        when(jwtTokenProvider.validateToken("expiredRefreshToken")).thenReturn(TokenValidationStatus.EXPIRED);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueAccessToken(testUserDetails, refreshRequestDto))
+                .isInstanceOf(RuntimeException.class); // TODO: '리프레시 토큰이 만료되었습니다.' 예외 작성 후 메시지 검증 추가
+
+        verify(refreshTokenService).getRefreshToken(1L);
+        verify(jwtTokenProvider, times(2)).validateToken(anyString());
+        verify(jwtTokenProvider).validateToken("validRefreshToken");
+        verify(jwtTokenProvider).validateToken("expiredRefreshToken");
+        verify(jwtTokenProvider, never()).generateAccessToken(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 실패 - 클라이언트와 서버 리프레시 토큰이 일치하지 않음")
+    void reissueAccessToken_Failure_RefreshTokenMismatch() {
+        // given
+        String serverRefreshToken = "differentRefreshToken";
+        
+        when(refreshTokenService.getRefreshToken(anyLong())).thenReturn(serverRefreshToken);
+        when(jwtTokenProvider.validateToken(anyString())).thenReturn(TokenValidationStatus.VALID);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueAccessToken(testUserDetails, refreshRequestDto))
+                .isInstanceOf(RuntimeException.class); // TODO: '유효하지 않은 리프레시 토큰입니다' 예외 작성 후 메시지 검증 추가
+
+        verify(refreshTokenService).getRefreshToken(1L);
+        verify(jwtTokenProvider, times(2)).validateToken(anyString());
+        verify(jwtTokenProvider).validateToken("validRefreshToken");
+        verify(jwtTokenProvider).validateToken("differentRefreshToken");
+        verify(jwtTokenProvider, never()).generateAccessToken(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 실패 - 서버 리프레시 토큰이 유효하지 않음")
+    void reissueAccessToken_Failure_InvalidServerRefreshToken() {
+        // given
+        String serverRefreshToken = "invalidRefreshToken";
+        
+        when(refreshTokenService.getRefreshToken(anyLong())).thenReturn(serverRefreshToken);
+        when(jwtTokenProvider.validateToken("validRefreshToken")).thenReturn(TokenValidationStatus.VALID);
+        when(jwtTokenProvider.validateToken("invalidRefreshToken")).thenReturn(TokenValidationStatus.INVALID);
+
+        // when & then
+        assertThatThrownBy(() -> authService.reissueAccessToken(testUserDetails, refreshRequestDto))
+                .isInstanceOf(RuntimeException.class); // TODO: '리프레시 토큰이 만료되었습니다.' 예외 작성 후 메시지 검증 추가
+
+        verify(refreshTokenService).getRefreshToken(1L);
+        verify(jwtTokenProvider, times(2)).validateToken(anyString());
+        verify(jwtTokenProvider).validateToken("validRefreshToken");
+        verify(jwtTokenProvider).validateToken("invalidRefreshToken");
+        verify(jwtTokenProvider, never()).generateAccessToken(anyString(), anyString());
     }
 }

--- a/src/test/java/com/zero/cohousesever/member/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/member/service/RefreshTokenServiceTest.java
@@ -1,0 +1,137 @@
+package com.zero.cohousesever.member.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 저장")
+    void saveRefreshToken() {
+        // given
+        Long memberId = 1L;
+        String refreshToken = "test-refresh-token";
+        long expirationMillis = 86400000L; // 24시간
+
+        // when
+        refreshTokenService.saveRefreshToken(memberId, refreshToken, expirationMillis);
+
+        // then
+        verify(valueOperations).set("RT:1", refreshToken, expirationMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("멤버 ID로 리프레시 토큰 조회")
+    void getRefreshToken() {
+        // given
+        Long memberId = 1L;
+        String expectedToken = "test-refresh-token";
+        when(valueOperations.get("RT:1")).thenReturn(expectedToken);
+
+        // when
+        String result = refreshTokenService.getRefreshToken(memberId);
+
+        // then
+        assertThat(result).isEqualTo(expectedToken);
+        verify(valueOperations).get("RT:1");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 멤버 ID로 조회 - null 반환")
+    void getRefreshToken_NotFound() {
+        // given
+        Long memberId = 999L;
+        when(valueOperations.get("RT:999")).thenReturn(null);
+
+        // when
+        String result = refreshTokenService.getRefreshToken(memberId);
+
+        // then
+        assertThat(result).isNull();
+        verify(valueOperations).get("RT:999");
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 삭제")
+    void deleteRefreshToken() {
+        // given
+        Long memberId = 1L;
+
+        // when
+        refreshTokenService.deleteRefreshToken(memberId);
+
+        // then
+        verify(stringRedisTemplate).delete("RT:1");
+    }
+
+    @Test
+    @DisplayName("키 프리픽스 검사")
+    void keyPrefixIsCorrect() {
+        // given & when
+        String keyPrefix = (String) ReflectionTestUtils.getField(refreshTokenService, "REFRESH_TOKEN_KEY_PREFIX");
+
+        // then
+        assertThat(keyPrefix).isEqualTo("RT:");
+    }
+
+    @Test
+    @DisplayName("여러 멤버의 리프레시 토큰 저장")
+    void saveMultipleRefreshTokens() {
+        // given
+        Long memberId1 = 1L;
+        Long memberId2 = 2L;
+        String token1 = "token-1";
+        String token2 = "token-2";
+        long expirationMillis = 86400000L;
+
+        // when
+        refreshTokenService.saveRefreshToken(memberId1, token1, expirationMillis);
+        refreshTokenService.saveRefreshToken(memberId2, token2, expirationMillis);
+
+        // then
+        verify(valueOperations).set("RT:1", token1, expirationMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
+        verify(valueOperations).set("RT:2", token2, expirationMillis, java.util.concurrent.TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 저장 시 만료 시간 검증")
+    void saveRefreshTokenWithExpiration() {
+        // given
+        Long memberId = 1L;
+        String refreshToken = "test-token";
+        long expirationMillis = 3600000L; // 1시간
+
+        // when
+        refreshTokenService.saveRefreshToken(memberId, refreshToken, expirationMillis);
+
+        // then
+        verify(valueOperations).set(eq("RT:1"), eq(refreshToken), eq(expirationMillis), eq(java.util.concurrent.TimeUnit.MILLISECONDS));
+    }
+}


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
로그인 리프레시 통한 액세스 토큰 재발급 기능 구현, JWT 인증 필터 수정

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
1. JwtTokenProivder의 `validateToken()` 메서드가 `boolean` 대신 `TokenValidationStatus`를 반환하도록 변경
2. JwtAuthenticationFilter의 doFilterInternal 로직을 수정하여 리프레시 요청이 제대로 통과되도록 변경
3. 로그인 리프레시 api 구현: 컨트롤러/서비스 작성, 레디스에 리프레시 토큰 저장하는 서비스 추가

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->
API의 /members/login/refresh 구현
JWT 인증 관련 문제 수정

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->
- 리프레시 토큰은 Redis에 저장하여 빠르게 조회하며 TTL 설정을 통해 수명 관리
- JWT 인증 필터에서 만료된 토큰에 대해 리프레시 요청을 구분하기 위해 `validateToken()`에서 boolean 대신 status 도입

---

## Work Done
<!-- 구체적인 작업 내역 -->
1. RedisConfig 추가
2. JwtTokenProvider 수정
    - `validateToken()` 메서드가 `boolean` 대신 `TokenValidationStatus`를 반환하도록 변경
3. JwtAuthenticationFilter의 doFilterInternal 수정
    - 토큰이 null인 경우 인증 필터 통과하도록 동작(토큰이 아직 존재하지 않는 회원가입, 로그인 등에 적용)
    - 토큰이 유효하거나, 만료된 토큰이 /members/login/refresh 요청인 경우 인증 정보 생성
5. 로그인 리프레시 api 구현
    - 기존 로그인 로직(`loginAuthenticate()`)에 리프레시 토큰 레디스에 저장하는 로직 추가
    - `reissueAccessToken()` 메서드 구현
    - `RefreshTokenService` 클래스 생성: 리프레시 토큰을 레디스에 저장/조회/삭제하는 서비스

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->
- 서비스 로직 테스트: 테스트 코드 참고

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->
예외는 공통예외 구조가 생성된 이후 추가할 예정

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #49 