### PR TITLE
Feature: #39 - 게시글 삭제 기능 구현

### DIFF
--- a/src/main/java/com/zero/cohousesever/post/controller/PostController.java
+++ b/src/main/java/com/zero/cohousesever/post/controller/PostController.java
@@ -52,7 +52,7 @@ public class PostController {
      * 게시글 수정
      *  존재하지 않거나 삭제(deleted=true)된 경우 404
      */
-    @PutMapping("/{postId}")
+    @PutMapping("/{id}")
     public ResponseEntity<PostResponse> updatePost(
             @PathVariable Long id,
             @RequestBody PostUpdateRequest request
@@ -64,9 +64,9 @@ public class PostController {
     /**
      * 게시글 삭제
      */
-    @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long postId) {
-        return ResponseEntity.noContent().build();
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long id) {
+        return ResponseEntity.noContent().build(); // 204
     }
 
 //    /**

--- a/src/main/java/com/zero/cohousesever/post/service/PostService.java
+++ b/src/main/java/com/zero/cohousesever/post/service/PostService.java
@@ -105,11 +105,19 @@ public class PostService {
 
     /**
      * 게시글 삭제
+     * - ACTIVE인 글만 삭제 가능
+     * - 대상이 없거나 이미 삭제된 경우 NoSuchElementException
      */
-    public void deletePost(Long postId) {
-
+    public void deletePost(Long id) {
+        Post post = postRepository.findByIdAndStatus(id, PostStatus.ACTIVE)
+                .orElseThrow(() -> new NoSuchElementException("post not found or already deleted"));
+        post.setStatus(PostStatus.DELETED);
+        postRepository.save(post);
     }
 
+//    /**
+//     * 게시글 상단 고정
+//     */
 //    public void pinPost(Long postId) {
 //
 //    }

--- a/src/test/java/com/zero/cohousesever/post/service/PostServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/post/service/PostServiceTest.java
@@ -270,6 +270,41 @@ class PostServiceTest {
                 .isInstanceOf(NoSuchElementException.class);
     }
 
+    @Test
+    @DisplayName("삭제 성공 - ACTIVE 글을 DELETED로 전환")
+    void delete_success() {
+        // given
+        Post post = Post.builder()
+                .groupId(1L)
+                .memberId(5L)
+                .type(PostType.FREE)
+                .title("t")
+                .content("c")
+                .status(PostStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(post, "id", 100L);
+        ReflectionTestUtils.setField(post, "createdAt", LocalDateTime.now().minusDays(1));
+        ReflectionTestUtils.setField(post, "updatedAt", LocalDateTime.now().minusHours(1));
+
+        when(postRepository.findByIdAndStatus(100L, PostStatus.ACTIVE)).thenReturn(Optional.of(post));
+        when(postRepository.save(any(Post.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        postService.deletePost(100L);
+
+        // then
+        verify(postRepository).save(argThat(p -> p.getStatus() == PostStatus.DELETED));
+    }
+
+    @Test
+    @DisplayName("삭제 실패 - 대상 없음 또는 이미 삭제됨 → 404 매핑용 예외")
+    void delete_notFound_or_alreadyDeleted() {
+        when(postRepository.findByIdAndStatus(999L, PostStatus.ACTIVE)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> postService.deletePost(999L))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
     // -------------------------
     // 테스트용 헬퍼 (오버로드 포함)
     // -------------------------


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->

- 게시글 삭제 시 소프트 삭제(Active → Deleted) 로 상태 전환

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->

- Service: deletePost(id) 구현
   - ACTIVE 상태 게시글만 조회 후 status = DELETED 로 변경
   - 대상이 없거나 이미 삭제된 경우 NoSuchElementException 발생
- Controller: DELETE /api/posts/{id} → 204 No Content 반환
- Test: Service 단위 테스트 추가 (PostServiceDeleteTest)

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->

- 실제 삭제가 아닌 논리 삭제(soft delete) 방식 적용

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->

- 데이터 무결성과 이력 보존을 위해 하드 삭제 대신 소프트 삭제 채택
- 유지보수성: PostStatus Enum 기반으로 상태 관리 일원화

---

## Work Done
<!-- 구체적인 작업 내역 -->
- PostService.deletePost 구현
- PostController DELETE 엔드포인트 연결
- PostRepository.findByIdAndStatus 활용

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

- JUnit 단위 테스트 모두 통과

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

- 변경된 파일:
   - /service/PostService.java (삭제 로직 추가)
   - /controller/PostController.java (DELETE 엔드포인트)
   - /test/PostServiceDeleteTest.java (단위 테스트)
- 추후 작업: 목록/상세 조회에도 status=ACTIVE 필터 반영 필요

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #39 
