### PR TITLE
Feature: #80 - 회원 도메인 예외 처리

### DIFF
--- a/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
+++ b/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
@@ -10,8 +10,14 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 회원 관련 오류
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원을 찾을 수 없습니다."),
-    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
-    MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
+    MEMBER_INACTIVE(HttpStatus.UNAUTHORIZED, "이미 탈퇴한 회원입니다."),
+    INVALID_SIGNUP_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 회원가입 요청입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 등록된 이메일입니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    ACCESS_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
 
     // 그룹 관련 오류
 

--- a/src/main/java/com/zero/cohousesever/member/dto/auth/SignupRequestDto.java
+++ b/src/main/java/com/zero/cohousesever/member/dto/auth/SignupRequestDto.java
@@ -10,5 +10,4 @@ public class SignupRequestDto {
     private String email;
     private String name;
     private String password;
-    private String passwordRepeat;
 }

--- a/src/main/java/com/zero/cohousesever/member/security/CustomUserDetailsService.java
+++ b/src/main/java/com/zero/cohousesever/member/security/CustomUserDetailsService.java
@@ -1,12 +1,17 @@
 package com.zero.cohousesever.member.security;
 
+import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.enums.MemberStatus;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+
+import static com.zero.cohousesever.common.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +22,11 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(username)
-                .orElseThrow(() -> new RuntimeException()); // TODO: 적절한 예외 던지기
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        if (member.getStatus().equals(MemberStatus.INACTIVE)) {
+            throw new CustomException(MEMBER_INACTIVE);
+        }
 
         return new CustomUserDetails(member);
     }

--- a/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.member.security;
 
+import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -14,6 +15,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+
+import static com.zero.cohousesever.common.exception.ErrorCode.ACCESS_TOKEN_EXPIRED;
+import static com.zero.cohousesever.common.exception.ErrorCode.ACCESS_TOKEN_INVALID;
 
 @Component
 @RequiredArgsConstructor
@@ -38,25 +42,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             if (status == TokenValidationStatus.VALID ||
                     (status == TokenValidationStatus.EXPIRED && request.getRequestURI().equals("/members/login/refresh"))) {
-                try {
-                    String email = jwtTokenProvider.getEmailFromToken(token);
-                    UserDetails userDetails = userDetailsService.loadUserByUsername(email);
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                } catch (RuntimeException e) {
-                    // TODO: CustomUserDetailsService에서 던지는 예외 받기
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                    return;
-                }
+                String email = jwtTokenProvider.getEmailFromToken(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             } else if (status == TokenValidationStatus.EXPIRED) {
-                // TODO: 토큰 만료 예외 작성
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                return;
+                throw new CustomException(ACCESS_TOKEN_EXPIRED);
             } else if (status == TokenValidationStatus.INVALID) {
-                // TODO: 토큰 무효 예외 작성
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                return;
+                throw new CustomException(ACCESS_TOKEN_INVALID);
             }
         }
 

--- a/src/main/java/com/zero/cohousesever/member/service/AuthService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.zero.cohousesever.member.service;
 
+import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.member.dto.auth.JwtTokenResponseDto;
 import com.zero.cohousesever.member.dto.auth.LoginRequestDto;
 import com.zero.cohousesever.member.dto.auth.RefreshRequestDto;
@@ -15,6 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.util.Objects;
+
+import static com.zero.cohousesever.common.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -32,32 +36,27 @@ public class AuthService {
         String name = signupRequestDto.getName();
         String email = signupRequestDto.getEmail();
         String password = signupRequestDto.getPassword();
-        String passwordRepeat = signupRequestDto.getPasswordRepeat();
 
         // TODO: Validation 도입하여 처리하기
         if (!StringUtils.hasText(name)
                 || !StringUtils.hasText(email)
-                || !StringUtils.hasText(password)
-                || !StringUtils.hasText(passwordRepeat)) {
-            throw new RuntimeException(); // TODO: 적절한 예외 처리 로직 작성
-        }
-
-        if (!Objects.equals(password, passwordRepeat)) {
-            throw new RuntimeException(); // TODO: 적절한 예외 처리 로직 작성
+                || !StringUtils.hasText(password)) {
+            throw new CustomException(INVALID_SIGNUP_REQUEST);
         }
 
         if (isEmailDuplicated(email)) {
-            throw new RuntimeException(); // TODO: 적절한 예외 처리 로직 작성
+            throw new CustomException(EMAIL_ALREADY_EXISTS);
         }
 
         return memberService.createMember(name, email, passwordEncoder.encode(password));
     }
 
     public JwtTokenResponseDto loginAuthenticate(LoginRequestDto requestDto) {
-        Member member = memberRepository.findByEmail(requestDto.getEmail()).orElseThrow(); // TODO: 적절한 예외 처리
+        Member member = memberRepository.findByEmail(requestDto.getEmail())
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
         if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())) {
-            throw new RuntimeException(); // TODO: 적절한 예외 처리
+            throw new CustomException(PASSWORD_NOT_MATCH);
         }
 
         String accessToken = jwtTokenProvider.generateAccessToken(member.getEmail(), member.getName());
@@ -80,15 +79,15 @@ public class AuthService {
         String serverRefreshToken = refreshTokenService.getRefreshToken(userDetails.getId());
 
         if (!jwtTokenProvider.validateToken(memberRefreshToken).equals(TokenValidationStatus.VALID)) {
-            throw new RuntimeException(); // TODO: '유효하지 않은 리프레시 토큰입니다' 예외 작성
+            throw new CustomException(REFRESH_TOKEN_INVALID);
         }
 
         if (!jwtTokenProvider.validateToken(serverRefreshToken).equals(TokenValidationStatus.VALID)) {
-            throw new RuntimeException(); // TODO: '리프레시 토큰이 만료되었습니다.' 예외 작성
+            throw new CustomException(REFRESH_TOKEN_EXPIRED);
         }
 
         if (!Objects.equals(memberRefreshToken, serverRefreshToken)) {
-            throw new RuntimeException(); // TODO: '유효하지 않은 리프레시 토큰입니다' 예외 작성
+            throw new CustomException(REFRESH_TOKEN_INVALID);
         }
 
         String newAccessToken = jwtTokenProvider.generateAccessToken(userDetails.getEmail(), userDetails.getName());

--- a/src/test/java/com/zero/cohousesever/member/security/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/member/security/CustomUserDetailsServiceTest.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.member.security;
 
+import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.enums.MemberStatus;
 import com.zero.cohousesever.member.repository.MemberRepository;
@@ -68,7 +69,30 @@ class CustomUserDetailsServiceTest {
 
         // when & then
         assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername(email))
-                .isInstanceOf(RuntimeException.class); // TODO: loadUserByUsername에서 던진 예외를 캐치하기
+                .isInstanceOf(CustomException.class)
+                .hasMessage("해당 회원을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("만료된 사용자로 UserDetails 로드 시 예외 발생")
+    void shouldThrowExceptionWhenUserInactive() {
+        // given
+        String email = "test@example.com";
+        String name = "테스트 사용자";
+        String password = "password123";
+        Member member = Member.builder()
+                .name(name)
+                .email(email)
+                .password(password)
+                .status(MemberStatus.INACTIVE)
+                .build();
+
+        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+
+        // when & then
+        assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername(email))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 탈퇴한 회원입니다.");
     }
 
     @Test
@@ -80,7 +104,8 @@ class CustomUserDetailsServiceTest {
 
         // when & then
         assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername(emptyEmail))
-                .isInstanceOf(RuntimeException.class); // TODO: loadUserByUsername에서 던진 예외를 캐치하기
+                .isInstanceOf(CustomException.class)
+                .hasMessage("해당 회원을 찾을 수 없습니다.");
     }
 
     @Test
@@ -92,6 +117,7 @@ class CustomUserDetailsServiceTest {
 
         // when & then
         assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername(nullEmail))
-                .isInstanceOf(RuntimeException.class); // TODO: loadUserByUsername에서 던진 예외를 캐치하기
+                .isInstanceOf(CustomException.class)
+                .hasMessage("해당 회원을 찾을 수 없습니다.");
     }
 }

--- a/src/test/java/com/zero/cohousesever/member/service/AuthServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/member/service/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.member.service;
 
+import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.member.dto.auth.JwtTokenResponseDto;
 import com.zero.cohousesever.member.dto.auth.LoginRequestDto;
 import com.zero.cohousesever.member.dto.auth.RefreshRequestDto;
@@ -70,7 +71,6 @@ class AuthServiceTest {
         ReflectionTestUtils.setField(signupRequestDto, "email", "test@example.com");
         ReflectionTestUtils.setField(signupRequestDto, "name", "테스트유저");
         ReflectionTestUtils.setField(signupRequestDto, "password", "password123");
-        ReflectionTestUtils.setField(signupRequestDto, "passwordRepeat", "password123");
 
         // 로그인 요청 DTO
         loginRequestDto = new LoginRequestDto();
@@ -107,25 +107,6 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("회원가입 실패 - 비밀번호와 비밀번호 확인이 일치하지 않음")
-    void registerMember_Failure_PasswordMismatch() {
-        // given
-        SignupRequestDto invalidPasswordDto = new SignupRequestDto();
-        ReflectionTestUtils.setField(invalidPasswordDto, "email", "test@example.com");
-        ReflectionTestUtils.setField(invalidPasswordDto, "name", "테스트유저");
-        ReflectionTestUtils.setField(invalidPasswordDto, "password", "password123");
-        ReflectionTestUtils.setField(invalidPasswordDto, "passwordRepeat", "differentPassword");
-
-        // when & then
-        assertThatThrownBy(() -> authService.registerMember(invalidPasswordDto))
-                .isInstanceOf(RuntimeException.class); // TODO: 적절한 예외 처리 로직 작성 후 메시지 검증 추가
-
-        verify(memberRepository, never()).existsByEmail(anyString());
-        verify(passwordEncoder, never()).encode(anyString());
-        verify(memberService, never()).createMember(anyString(), anyString(), anyString());
-    }
-
-    @Test
     @DisplayName("회원가입 실패 - 이미 존재하는 이메일")
     void registerMember_Failure_DuplicateEmail() {
         // given
@@ -133,7 +114,8 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.registerMember(signupRequestDto))
-                .isInstanceOf(RuntimeException.class); // TODO: 적절한 예외 처리 로직 작성 후 메시지 검증 추가
+                .isInstanceOf(CustomException.class)
+                .hasMessage("이미 등록된 이메일입니다.");
 
         verify(memberRepository).existsByEmail("test@example.com");
         verify(passwordEncoder, never()).encode(anyString());
@@ -171,7 +153,8 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.loginAuthenticate(loginRequestDto))
-                .isInstanceOf(RuntimeException.class); // TODO: 적절한 예외 처리 로직 작성 후 메시지 검증 추가
+                .isInstanceOf(CustomException.class)
+                .hasMessage("해당 회원을 찾을 수 없습니다.");
 
         verify(memberRepository).findByEmail("test@example.com");
         verify(passwordEncoder, never()).matches(anyString(), anyString());
@@ -188,7 +171,8 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.loginAuthenticate(loginRequestDto))
-                .isInstanceOf(RuntimeException.class); // TODO: 적절한 예외 처리 로직 작성 후 메시지 검증 추가
+                .isInstanceOf(CustomException.class)
+                .hasMessage("비밀번호가 일치하지 않습니다.");
 
         verify(memberRepository).findByEmail("test@example.com");
         verify(passwordEncoder).matches("password123", "encodedPassword");
@@ -256,7 +240,8 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.reissueAccessToken(testUserDetails, refreshRequestDto))
-                .isInstanceOf(RuntimeException.class); // TODO: '유효하지 않은 리프레시 토큰입니다' 예외 작성 후 메시지 검증 추가
+                .isInstanceOf(CustomException.class)
+                .hasMessage("유효하지 않은 리프레시 토큰입니다.");
 
         verify(jwtTokenProvider).validateToken("validRefreshToken");
         verify(jwtTokenProvider, never()).generateAccessToken(anyString(), anyString());
@@ -274,7 +259,8 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.reissueAccessToken(testUserDetails, refreshRequestDto))
-                .isInstanceOf(RuntimeException.class); // TODO: '리프레시 토큰이 만료되었습니다.' 예외 작성 후 메시지 검증 추가
+                .isInstanceOf(CustomException.class)
+                .hasMessage("리프레시 토큰이 만료되었습니다.");
 
         verify(refreshTokenService).getRefreshToken(1L);
         verify(jwtTokenProvider, times(2)).validateToken(anyString());
@@ -294,7 +280,8 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.reissueAccessToken(testUserDetails, refreshRequestDto))
-                .isInstanceOf(RuntimeException.class); // TODO: '유효하지 않은 리프레시 토큰입니다' 예외 작성 후 메시지 검증 추가
+                .isInstanceOf(CustomException.class)
+                .hasMessage("유효하지 않은 리프레시 토큰입니다.");
 
         verify(refreshTokenService).getRefreshToken(1L);
         verify(jwtTokenProvider, times(2)).validateToken(anyString());
@@ -315,7 +302,8 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.reissueAccessToken(testUserDetails, refreshRequestDto))
-                .isInstanceOf(RuntimeException.class); // TODO: '리프레시 토큰이 만료되었습니다.' 예외 작성 후 메시지 검증 추가
+                .isInstanceOf(CustomException.class)
+                .hasMessage("리프레시 토큰이 만료되었습니다.");
 
         verify(refreshTokenService).getRefreshToken(1L);
         verify(jwtTokenProvider, times(2)).validateToken(anyString());


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
회원 도메인에 CustomException 도입
회원가입시 비밀번호 확인 검사 제거

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
- CustomException에 예외 코드 추가: 
  - MEMBER_INACTIVE
  - INVALID_SIGNUP_REQUEST
  - EMAIL_ALREADY_EXISTS
  - PASSWORD_NOT_MATCH
  - ACCESS_TOKEN_INVALID
  - ACCESS_TOKEN_EXPIRED
  - REFRESH_TOKEN_INVALID
  - REFRESH_TOKEN_EXPIRED
- RuntimeException 사용하던 부분을 CustomException으로 교체
  - AuthService: `registerMember`, `loginAuthenticate`, `reissueAccessToken`
  - JwtAuthenticationFilter: `doFilterInternal`
  - CustomUserDetailsService: `loadByUsername`
- registerMember에서 비밀번호 확인 검사 제거

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->
기존에 임시로 RuntimeException으로 처리하던 예외를 CustomException을 활용해 리팩토링
회원가입 시 비밀번호 확인 검사는 프론트에서만 수행

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->
- 확장성과 유지보수를 위해 CustomException 도입
- 비밀번호 확인 검사는 프론트에서만 수행(사용자 실수를 방지하기 위한 검사로 백엔드에서 검사 불필요하다고 판단)

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] CustomException에 예외 코드 추가
- [변경 2] AuthService 커스텀 예외 도입
  - `registerMember`: INVALID_SIGNUP_REQUEST, EMAIL_ALREADY_EXISTS
  - `loginAuthenticate`: MEMBER_NOT_FOUND, PASSWORD_NOT_MATCH
  - `reissueAccessToken`: REFRESH_TOKEN_INVALID, REFRESH_TOKEN_EXPIRED
- [변경 3] JwtAuthenticationFilter 커스텀 예외 도입
  - `doFilterInternal`: ACCESS_TOKEN_INVALID, ACCESS_TOKEN_EXPIRED
- [변경 4] CustomUserDetailsService 커스텀 예외 도입
  - `loadByUsername`: MEMBER_NOT_FOUND, MEMBER_INACTIVE
- [변경 5] `registerMember`에서 비밀번호 확인 검사 제거, SignupRequestDto에서 passwordRepeat 필드 제거
- [변경 6] 수정된 코드에 맞춰 테스트 코드 수정

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->
JUnit 테스트 통과

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #80 