### PR TITLE
Feature: #53 - 로그아웃 서비스 구현

### DIFF
--- a/src/main/java/com/zero/cohousesever/member/controller/AuthController.java
+++ b/src/main/java/com/zero/cohousesever/member/controller/AuthController.java
@@ -60,7 +60,12 @@ public class AuthController {
 
     // 로그아웃
     @PostMapping("/logout")
-    public ResponseEntity<MessageDto> logout() {
+    public ResponseEntity<Void> logout(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long memberId = userDetails.getId();
+
+        authService.logout(memberId);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/zero/cohousesever/member/service/AuthService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/AuthService.java
@@ -5,10 +5,10 @@ import com.zero.cohousesever.member.dto.auth.LoginRequestDto;
 import com.zero.cohousesever.member.dto.auth.RefreshRequestDto;
 import com.zero.cohousesever.member.dto.auth.SignupRequestDto;
 import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.member.security.CustomUserDetails;
 import com.zero.cohousesever.member.security.JwtTokenProvider;
-import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -97,5 +97,11 @@ public class AuthService {
                 .accessToken(newAccessToken)
                 .refreshToken(serverRefreshToken)
                 .build();
+    }
+
+    public void logout(Long memberId) {
+        // 로그아웃 시 액세스 토큰은 프론트에서 폐기
+        // 백엔드는 리프레시 토큰만 폐기
+        refreshTokenService.deleteRefreshToken(memberId);
     }
 }


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
회원 로그아웃 기능 구현

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
- AuthController: `logout` 메서드 구현
- AuthService: `logout` 메서드 추가
  - refreshTokenService의 `deleteRefreshToken` 메서드를 호출하여 redis에 저장된 리프레시 토큰 삭제

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->
API 명세에 따른 기능 구현

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->
- 로그아웃시 액세스 토큰과 리프레시 토큰을 모두 파기해야 하지만, 액세스 토큰은 프론트엔드에서 관리하므로 백엔드에서는 리프레시 토큰만 파기

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] AuthController에 `logout` 메서드 구현
- [변경 2] AuthService에 `logout` 메서드 추가

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->
서비스는 단순히 deleteRefreshToken을 호출하므로 테스트 미작성함

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #53 