### PR TITLE
Feature  #100 - 할 일 변경 요청 구현

### DIFF
--- a/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
+++ b/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
@@ -38,6 +38,16 @@ public enum ErrorCode {
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     GROUP_ID_REQUIRED(HttpStatus.BAD_REQUEST,  "그룹 아이디 확인이 필요합니다."),
     ASSIGNMENT_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, "할 일 상태 값이 필요합니다."),
+
+    OVERRIDE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "담당자 변경 요청을 찾을 수 없습니다."),
+    OVERRIDE_ALREADY_PROCESSED(HttpStatus.CONFLICT, "이미 처리된 요청입니다."),
+    OVERRIDE_PAST_DATE_FORBIDDEN(HttpStatus.BAD_REQUEST, "과거 날짜의 할일은 처리할 수 없습니다."),
+    OVERRIDE_REQUESTER_MUST_BE_ASSIGNEE(HttpStatus.FORBIDDEN, "현재 담당자만 요청을 생성할 수 있습니다."),
+    OVERRIDE_ACCEPTOR_MUST_BE_TARGET(HttpStatus.FORBIDDEN, "요청 대상자만 응답할 수 있습니다."),
+    OVERRIDE_BROADCAST_REJECT_FORBIDDEN(HttpStatus.FORBIDDEN, "브로드캐스트 요청은 거절할 수 없습니다."),
+    OVERRIDE_NOT_SAME_GROUP(HttpStatus.FORBIDDEN, "같은 그룹의 그룹멤버만 가능합니다."),
+    OVERRIDE_SWAP_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "스왑 대상 할일 배정을 찾을 수 없습니다."),
+    OVERRIDE_SWAP_DIFFERENT_GROUP(HttpStatus.FORBIDDEN, "서로 변경은 같은 그룹 내에서만 가능합니다."),
     // 게시물 관련 오류
 
     // 정산 관련 오류


### PR DESCRIPTION
pr올린 100번 승인없이 머지 되어서 에러코드만 수정후 다시 올립니다.

https://github.com/CoHouseTeam/cohouse-server/pull/122 확인해 주시면 감사하겠습니다.
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
할 일 변경 요청 기능 추가
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
 - Controller
   - POST /api/tasks/assignments/{assignmentId}/override-request -> 변경요청 생성
   - PATCH /api/tasks/override-requests/{requestId} -> 요청 수락/거절 (PUT -> PATCH)
 - Service
   - AssignmentOverrideService#createOverrideRequests(Long assignmentId, AssignmentOverrideRequest req)
   - AssignmentOverrideService#respondToOverrideRequest(Long requestId, AssignmentOverrideStatusUpdateRequest req)
 - 기능 설명
   - 지정요청/다중요청/전체요청(targetId=0L) 생성
   - 스왑 요청 시 수락하면 두 배정의 담당자 교환
   - 수락 시 동일 배정의 다른 REQUESTED 요청 일괄 REJECTED
   - 과거 날짜 요청/응답 금지, 같은 그룹 멤버만 가능, 생성자는 현 담당자만 가능
   - board.api.url 설정 시 생성 시 게시판 자동 알림(미설정 시 NO-OP) 보드, 알림 통합후 수정예쩡
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->

---

## Context
<!-- 변경이 발생한 배경/상황 -->
주간 할일 운영 중 결원/스케줄 변경에 따른 담당자 교체/맞교환 요구사항 반영
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
  - PATCH로 부분 상태 전이(ACCEPTED/REJECTED) 표현, 비멱등 부작용(일괄 거절)과 의미 일치
  - Bulk Update로 동일 배정 대기요청 일괄 상태 변경 -> 성능/일관성 확보
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] TaskController#requestOverride(POST) 구현, TaskController#respondOverride(PATCH) 구현
- [변경 2] AssignmentOverrideService 생성/응답
- [변경 3] AssignmentOverrideRepository, TaskAssignmentRepository 수정
- [변경 4] 에러코드 추가

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
 - JUnit(단위)
   - 브로드캐스트 요청 생성 성공(중복 방지)
   - 다른 그룹 대상 지정 시 예외
   - 브로드캐스트, 스왑 수락 시 담당자 변경 & 동일 배정 대기요청 일괄 REJECT
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
 - 변경된 파일
   - errodcode
   - taskcontroller
   - dto/override 폴더 전체
   - repository/TaskAssignmentRepository, AssignmentOverrideRepository
   - service/AssignmentOverrideService

<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
Closes #100 
<!-- ex: Closes #123 -->

