### PR TITLE
Fix: #186 - requestMatchers 경로 수정

### DIFF
--- a/src/main/java/com/zero/cohousesever/common/config/SecurityConfig.java
+++ b/src/main/java/com/zero/cohousesever/common/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/**",
+                                "/**", // TODO: 최종 배포 전에 제거할 것
                                 "/api/members/signup",
                                 "/api/members/check/**",
                                 "/api/members/login",

--- a/src/main/java/com/zero/cohousesever/common/config/SecurityConfig.java
+++ b/src/main/java/com/zero/cohousesever/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
-package com.zero.cohousesever.member.security;
+package com.zero.cohousesever.common.config;
 
+import com.zero.cohousesever.member.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,12 +34,12 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/**",
-                                "/members/signup",
-                                "/members/check/**",
-                                "/members/login",
-                                "/members/forgot-password",
-                                "/members/reset-password",
-                                "/members/oauth2/**"
+                                "/api/members/signup",
+                                "/api/members/check/**",
+                                "/api/members/login",
+                                "/api/members/forgot-password",
+                                "/api/members/reset-password",
+                                "/api/members/oauth2/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
SecurityConfig의 securityFilterChain의 requestMatchers 경로 수정
SecurityConfig를 config 디렉토리로 이동

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
- AuthController 매핑을 `/api/members`로 수정함에 따라 requestMatchers 내의 경로도 이에 맞춰 수정 

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->
버그 리포트

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1]
- [변경 2]
- [변경 3]

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #186 