### PR TITLE
Fix: #187 - 그룹 중복 생성 방지

### DIFF
--- a/src/main/java/com/zero/cohousesever/group/service/GroupService.java
+++ b/src/main/java/com/zero/cohousesever/group/service/GroupService.java
@@ -42,6 +42,10 @@ public class GroupService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
 
+        if (groupMemberRepository.existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE)) {
+            throw new CustomException(ALREADY_IN_GROUP);
+        }
+
         GroupMember leader = GroupMember.builder()
                 .member(member)
                 .nickname(member.getName()) // 이름을 기본 닉네임으로 사용
@@ -54,7 +58,6 @@ public class GroupService {
                 .name(groupNameDto.getGroupName())
                 .status(GroupStatus.ACTIVE)
                 .build();
-
 
         group.addMember(leader);
 

--- a/src/test/java/com/zero/cohousesever/group/service/GroupServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/group/service/GroupServiceTest.java
@@ -96,6 +96,8 @@ class GroupServiceTest {
         // given
         Long memberId = 1L;
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(groupMemberRepository.existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE))
+                .thenReturn(false);
         when(groupRepository.save(any(Group.class))).thenReturn(testGroup);
 
         // when
@@ -107,6 +109,7 @@ class GroupServiceTest {
         assertThat(result.getStatus()).isEqualTo(GroupStatus.ACTIVE);
 
         verify(memberRepository).findById(memberId);
+        verify(groupMemberRepository).existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE);
         verify(groupRepository).save(any(Group.class));
     }
 
@@ -120,9 +123,29 @@ class GroupServiceTest {
         // when & then
         assertThatThrownBy(() -> groupService.createGroup(memberId, groupNameDto))
                 .isInstanceOf(CustomException.class)
-                .hasMessage("해당 회원을 찾을 수 없습니다.");
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
 
         verify(memberRepository).findById(memberId);
+        verify(groupRepository, never()).save(any(Group.class));
+        verify(groupMemberRepository, never()).save(any(GroupMember.class));
+    }
+
+    @Test
+    @DisplayName("그룹 생성 시 이미 그룹에 속해있는 경우 예외 발생 테스트")
+    void createGroup_ThrowsException_WhenMemberAlreadyInGroup() {
+        // given
+        Long memberId = 999L;
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(groupMemberRepository.existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE))
+                .thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> groupService.createGroup(memberId, groupNameDto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ALREADY_IN_GROUP.getMessage());
+
+        verify(memberRepository).findById(memberId);
+        verify(groupMemberRepository).existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE);
         verify(groupRepository, never()).save(any(Group.class));
         verify(groupMemberRepository, never()).save(any(GroupMember.class));
     }
@@ -133,6 +156,8 @@ class GroupServiceTest {
         // given
         Long memberId = 1L;
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMember));
+        when(groupMemberRepository.existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE))
+                .thenReturn(false);
         when(groupRepository.save(any(Group.class))).thenReturn(testGroup);
 
         // when
@@ -212,7 +237,7 @@ class GroupServiceTest {
         // when & then
         assertThatThrownBy(() -> groupService.getGroup(groupId))
                 .isInstanceOf(CustomException.class)
-                .hasMessage("해당 그룹을 찾을 수 없습니다.");
+                .hasMessage(GROUP_NOT_FOUND.getMessage());
 
         verify(groupRepository).findById(groupId);
     }
@@ -277,7 +302,7 @@ class GroupServiceTest {
         // when & then
         assertThatThrownBy(() -> groupService.updateGroup(memberId, groupId, requestDto))
                 .isInstanceOf(CustomException.class)
-                .hasMessage("그룹장만 접근할 수 있습니다.");
+                .hasMessage(NOT_GROUP_LEADER.getMessage());
 
         verify(groupMemberRepository).findByMemberIdAndGroupId(memberId, groupId);
         verify(groupRepository, never()).save(any(Group.class));
@@ -301,7 +326,7 @@ class GroupServiceTest {
         // when & then
         assertThatThrownBy(() -> groupService.updateGroup(memberId, groupId, requestDto))
                 .isInstanceOf(CustomException.class)
-                .hasMessage("해당 그룹 멤버를 찾을 수 없습니다."); // GROUP_MEMBER_NOT_FOUND 메시지로 교체
+                .hasMessage(GROUP_MEMBER_NOT_FOUND.getMessage());
 
         verify(groupMemberRepository).findByMemberIdAndGroupId(memberId, groupId);
         verify(groupRepository, never()).save(any(Group.class));
@@ -327,7 +352,7 @@ class GroupServiceTest {
         // when & then
         assertThatThrownBy(() -> groupService.updateGroup(memberId, groupId, requestDto))
                 .isInstanceOf(CustomException.class)
-                .hasMessage("해당 그룹을 찾을 수 없습니다."); // GROUP_NOT_FOUND 메시지
+                .hasMessage(GROUP_NOT_FOUND.getMessage());
 
         verify(groupRepository, never()).save(any(Group.class));
     }


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
그룹 생성 api에서 그룹을 중복으로 생성할 수 있는 문제 수정

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
- GroupService: 현재 멤버가 그룹에 속해있는지 검사하는 로직 추가

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->
버그 리포트

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->
- 그룹에 속해 있는 경우 프론트에서 그룹 생성 버튼 자체는 사라지지만, 백엔드에 api 요청이 여러 번 들어올 경우 그룹 중복 검사 로직 부재로 인해 그룹이 중복으로 생성되는 문제 발생 -> 중복 검사 로직을 추가하여 해당 부분을 해결

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] GroupService에 그룹 중복 검사 로직 추가
- [변경 2] 서비스 테스트 코드 리팩토링

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #187 