### PR TITLE
Fix: #203 - 할 일 배정 오류 수정

### DIFF
--- a/src/main/java/com/zero/cohousesever/tasks/controller/TaskController.java
+++ b/src/main/java/com/zero/cohousesever/tasks/controller/TaskController.java
@@ -30,7 +30,6 @@ import com.zero.cohousesever.tasks.service.TaskAssignmentHistoryService;
 import com.zero.cohousesever.tasks.service.TaskAssignmentService;
 import com.zero.cohousesever.tasks.service.TaskTemplateService;
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -98,7 +97,9 @@ public class TaskController {
   }
 
   private List<Long> normalizeToMemberIds(Long groupId, List<Long> ids) {
-    if (ids == null) return List.of();
+    if (ids == null) {
+      return List.of();
+    }
     return ids.stream().map(id -> normalizeToMemberId(groupId, id)).toList();
   }
 
@@ -126,7 +127,8 @@ public class TaskController {
     ensureLeader(user.getId(), request.getGroupId());
 
     TaskTemplate saved = taskTemplateService.createTemplate(
-        request.getGroupId(), request.getCategory(), request.getRepeatDays(), request.getRandomEnabled());
+        request.getGroupId(), request.getCategory(), request.getRepeatDays(),
+        request.getRandomEnabled());
     return ResponseEntity.ok(TaskTemplateResponse.from(saved));
   }
 
@@ -158,7 +160,6 @@ public class TaskController {
     taskTemplateService.deleteTemplate(templateId);
     return ResponseEntity.noContent().build();
   }
-
 
   // 2. 반복 요일 관련
 
@@ -253,9 +254,10 @@ public class TaskController {
       request.setFixedAssigneeId(
           normalizeToMemberId(request.getGroupId(), request.getFixedAssigneeId()));
     }
-
     var created = taskAssignmentService.assignTaskManuallyOrRandomly(request);
-    if (created == null || created.isEmpty()) return ResponseEntity.noContent().build();
+    if (created == null || created.isEmpty()) {
+      return ResponseEntity.noContent().build();
+    }
     return ResponseEntity.ok(created.get(0));
   }
 
@@ -305,7 +307,6 @@ public class TaskController {
     ensureMember(user.getId(), groupId);
     return ResponseEntity.ok(taskAssignmentService.getUncompletedThisWeekByMember(groupId));
   }
-
 
   // 4. 담당자 변경 요청 관련
 

--- a/src/main/java/com/zero/cohousesever/tasks/controller/TaskController.java
+++ b/src/main/java/com/zero/cohousesever/tasks/controller/TaskController.java
@@ -2,10 +2,8 @@ package com.zero.cohousesever.tasks.controller;
 
 import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
-import com.zero.cohousesever.group.entity.Group;
 import com.zero.cohousesever.group.repository.GroupMemberRepository;
 import com.zero.cohousesever.group.repository.GroupRepository;
-import com.zero.cohousesever.member.entity.Member;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.member.security.CustomUserDetails;
 import com.zero.cohousesever.tasks.dto.assignment.TaskAssignmentRequest;
@@ -59,49 +57,7 @@ public class TaskController {
   private final AssignmentOverrideRepository assignmentOverrideRepository;
   private final TaskAssignmentHistoryService taskAssignmentHistoryService;
   private final AssignmentOverrideHistoryService assignmentOverrideHistoryService;
-
-  private final MemberRepository memberRepository;
-  private final GroupRepository groupRepository;
   private final GroupMemberRepository groupMemberRepository;
-
-  // 그룹장 여부
-  private void ensureLeader(Long memberId, Long groupId) {
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-    Group group = groupRepository.findById(groupId)
-        .orElseThrow(() -> new CustomException(ErrorCode.GROUP_NOT_FOUND));
-
-    if (!groupMemberRepository.existsByGroupAndMemberAndIsLeaderTrue(group, member)) {
-      throw new CustomException(ErrorCode.NOT_GROUP_LEADER);
-    }
-  }
-
-  //그룹원 확인
-  private void ensureMember(Long memberId, Long groupId) {
-    if (!groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
-      throw new CustomException(ErrorCode.GROUP_MEMBER_NOT_FOUND);
-    }
-  }
-
-  // MemberId, GroupMemberId 오류로 인한 정규화
-  private Long normalizeToMemberId(Long groupId, Long maybeMemberOrGroupMemberId) {
-    // 이미 memberId인지 빠른 체크
-    if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, maybeMemberOrGroupMemberId)) {
-      return maybeMemberOrGroupMemberId; // memberId
-    }
-    // group_member.id로 역조회 → memberId 추출
-    return groupMemberRepository.findById(maybeMemberOrGroupMemberId)
-        .filter(gm -> gm.getGroup().getId().equals(groupId))
-        .map(gm -> gm.getMember().getId())
-        .orElseThrow(() -> new CustomException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
-  }
-
-  private List<Long> normalizeToMemberIds(Long groupId, List<Long> ids) {
-    if (ids == null) {
-      return List.of();
-    }
-    return ids.stream().map(id -> normalizeToMemberId(groupId, id)).toList();
-  }
 
   // 1. 템플릿 관련
 
@@ -111,7 +67,7 @@ public class TaskController {
       @AuthenticationPrincipal CustomUserDetails user,
       @RequestParam Long groupId
   ) {
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
     List<TaskTemplateResponse> body = taskTemplateService.getAllTemplates(groupId).stream()
         .map(TaskTemplateResponse::from)
         .toList();
@@ -124,9 +80,12 @@ public class TaskController {
       @AuthenticationPrincipal CustomUserDetails user,
       @RequestBody TaskTemplateRequest request) {
 
-    ensureLeader(user.getId(), request.getGroupId());
+    if (user == null) {
+      throw new CustomException(ErrorCode.ACCESS_TOKEN_INVALID);
+    }
+    taskAssignmentService.ensureLeader(user.getId(), request.getGroupId());
 
-    TaskTemplate saved = taskTemplateService.createTemplate(
+    var saved = taskTemplateService.createTemplate(
         request.getGroupId(), request.getCategory(), request.getRepeatDays(),
         request.getRandomEnabled());
     return ResponseEntity.ok(TaskTemplateResponse.from(saved));
@@ -142,7 +101,7 @@ public class TaskController {
 
     // 템플릿 -> groupId 먼저 알아와서 체크
     TaskTemplate t = taskTemplateService.getById(templateId); // 없으면 내부에서 예외
-    ensureLeader(user.getId(), t.getGroupId());
+    taskAssignmentService.ensureLeader(user.getId(), t.getGroupId());
 
     TaskTemplate updated = taskTemplateService.updateTemplate(templateId, request.getCategory());
     return ResponseEntity.ok(TaskTemplateResponse.from(updated));
@@ -155,7 +114,7 @@ public class TaskController {
       @PathVariable Long templateId) {
 
     TaskTemplate t = taskTemplateService.getById(templateId);
-    ensureLeader(user.getId(), t.getGroupId());
+    taskAssignmentService.ensureLeader(user.getId(), t.getGroupId());
 
     taskTemplateService.deleteTemplate(templateId);
     return ResponseEntity.noContent().build();
@@ -170,7 +129,7 @@ public class TaskController {
       @PathVariable Long templateId
   ) {
     Long groupId = taskTemplateService.getGroupIdByTemplateId(templateId);
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
     return ResponseEntity.ok(repeatDayService.getRepeatDaysByTemplateId(templateId));
   }
 
@@ -182,7 +141,7 @@ public class TaskController {
       @RequestBody RepeatDayRequest request) {
 
     TaskTemplate t = taskTemplateService.getById(templateId);
-    ensureLeader(user.getId(), t.getGroupId());
+    taskAssignmentService.ensureLeader(user.getId(), t.getGroupId());
 
     return ResponseEntity.ok(repeatDayService.addRepeatDay(templateId, request));
   }
@@ -196,7 +155,7 @@ public class TaskController {
       @RequestBody RepeatDayRequest request
   ) {
     TaskTemplate t = taskTemplateService.getById(templateId);
-    ensureLeader(user.getId(), t.getGroupId());
+    taskAssignmentService.ensureLeader(user.getId(), t.getGroupId());
 
     RepeatDayResponse updated = repeatDayService.updateRepeatDay(templateId, repeatDayId, request);
     return ResponseEntity.ok(updated);
@@ -211,7 +170,7 @@ public class TaskController {
       @PathVariable Long repeatDayId) {
 
     TaskTemplate t = taskTemplateService.getById(templateId);
-    ensureLeader(user.getId(), t.getGroupId());
+    taskAssignmentService.ensureLeader(user.getId(), t.getGroupId());
 
     repeatDayService.deleteRepeatDay(templateId, repeatDayId);
     return ResponseEntity.noContent().build();
@@ -228,7 +187,7 @@ public class TaskController {
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
       @RequestParam(required = false) Long memberId
   ) {
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
 
     if (memberId != null &&
         !groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
@@ -243,17 +202,18 @@ public class TaskController {
       @AuthenticationPrincipal CustomUserDetails user,
       @RequestBody TaskAssignmentRequest request) {
 
-    ensureLeader(user.getId(), request.getGroupId());
+    taskAssignmentService.ensureLeader(user.getId(), request.getGroupId());
 
     // 후보와 고정 배정자만 memberId로 정규화
     if (request.getGroupMemberId() != null) {
       request.setGroupMemberId(
-          normalizeToMemberIds(request.getGroupId(), request.getGroupMemberId()));
+          taskAssignmentService.toMemberIds(request.getGroupId(), request.getGroupMemberId()));
     }
     if (request.getFixedAssigneeId() != null) {
       request.setFixedAssigneeId(
-          normalizeToMemberId(request.getGroupId(), request.getFixedAssigneeId()));
+          taskAssignmentService.toMemberId(request.getGroupId(), request.getFixedAssigneeId()));
     }
+
     var created = taskAssignmentService.assignTaskManuallyOrRandomly(request);
     if (created == null || created.isEmpty()) {
       return ResponseEntity.noContent().build();
@@ -274,7 +234,7 @@ public class TaskController {
     Long groupId = a.getTemplate().getGroupId();
     Long assigneeId = a.getGroupMemberId();
 
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
 
     if (!user.getId().equals(assigneeId)) {
       throw new CustomException(ErrorCode.INVALID_REQUEST);
@@ -291,7 +251,7 @@ public class TaskController {
       @RequestParam Long groupId,
       @RequestParam(required = false) Long memberId
   ) {
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
     if (memberId != null &&
         !groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
       throw new CustomException(ErrorCode.GROUP_MEMBER_NOT_FOUND);
@@ -304,7 +264,7 @@ public class TaskController {
       @AuthenticationPrincipal CustomUserDetails user,
       @RequestParam Long groupId
   ) {
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
     return ResponseEntity.ok(taskAssignmentService.getUncompletedThisWeekByMember(groupId));
   }
 
@@ -321,16 +281,16 @@ public class TaskController {
         .orElseThrow(() -> new CustomException(ErrorCode.TASK_ASSIGNMENT_NOT_FOUND));
     Long groupId = a.getTemplate().getGroupId();
 
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
 
     request.setRequesterId(user.getId());
 
     // 대상자 단일/다중 정규화 (있으면)
     if (request.getTargetId() != null) {
-      request.setTargetId(normalizeToMemberId(groupId, request.getTargetId()));
+      request.setTargetId(taskAssignmentService.toMemberId(groupId, request.getTargetId()));
     }
     if (request.getTargetIds() != null && !request.getTargetIds().isEmpty()) {
-      request.setTargetIds(normalizeToMemberIds(groupId, request.getTargetIds()));
+      request.setTargetIds(taskAssignmentService.toMemberIds(groupId, request.getTargetIds()));
     }
 
     var created = assignmentOverrideService.createOverrideRequests(assignmentId, request);
@@ -348,10 +308,13 @@ public class TaskController {
         .orElseThrow(() -> new CustomException(ErrorCode.OVERRIDE_REQUEST_NOT_FOUND));
     Long groupId = r.getAssignment().getTemplate().getGroupId();
 
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
 
-    Long normalizedActorId = normalizeToMemberId(groupId, request.getActorMemberId());
-    request.setActorMemberId(normalizedActorId);
+    Long actor = request.getActorMemberId();
+    if (actor == null) {
+      actor = user.getId();
+    }
+    request.setActorMemberId(taskAssignmentService.toMemberId(groupId, actor));
 
     var updated = assignmentOverrideService.respondToOverrideRequest(requestId, request);
     return ResponseEntity.ok(updated);
@@ -367,7 +330,7 @@ public class TaskController {
         .orElseThrow(() -> new CustomException(ErrorCode.TASK_ASSIGNMENT_NOT_FOUND));
 
     Long groupId = a.getTemplate().getGroupId();
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
 
     return ResponseEntity.ok(taskAssignmentHistoryService.getAssignmentHistories(assignmentId));
   }
@@ -382,7 +345,7 @@ public class TaskController {
         .orElseThrow(() -> new CustomException(ErrorCode.OVERRIDE_REQUEST_NOT_FOUND));
 
     Long groupId = r.getAssignment().getTemplate().getGroupId();
-    ensureMember(user.getId(), groupId);
+    taskAssignmentService.ensureMember(user.getId(), groupId);
 
     return ResponseEntity.ok(assignmentOverrideHistoryService.getOverrideHistories(requestId));
   }

--- a/src/main/java/com/zero/cohousesever/tasks/controller/TaskController.java
+++ b/src/main/java/com/zero/cohousesever/tasks/controller/TaskController.java
@@ -84,6 +84,24 @@ public class TaskController {
     }
   }
 
+  // MemberId, GroupMemberId 오류로 인한 정규화
+  private Long normalizeToMemberId(Long groupId, Long maybeMemberOrGroupMemberId) {
+    // 이미 memberId인지 빠른 체크
+    if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, maybeMemberOrGroupMemberId)) {
+      return maybeMemberOrGroupMemberId; // memberId
+    }
+    // group_member.id로 역조회 → memberId 추출
+    return groupMemberRepository.findById(maybeMemberOrGroupMemberId)
+        .filter(gm -> gm.getGroup().getId().equals(groupId))
+        .map(gm -> gm.getMember().getId())
+        .orElseThrow(() -> new CustomException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+  }
+
+  private List<Long> normalizeToMemberIds(Long groupId, List<Long> ids) {
+    if (ids == null) return List.of();
+    return ids.stream().map(id -> normalizeToMemberId(groupId, id)).toList();
+  }
+
   // 1. 템플릿 관련
 
   // 조회
@@ -226,20 +244,20 @@ public class TaskController {
 
     ensureLeader(user.getId(), request.getGroupId());
 
-    // 후보 멤버 전원 검증
+    // 후보와 고정 배정자만 memberId로 정규화
     if (request.getGroupMemberId() != null) {
-      for (Long mid : request.getGroupMemberId()) {
-        if (!groupMemberRepository.existsByGroupIdAndMemberId(request.getGroupId(), mid)) {
-          throw new CustomException(ErrorCode.GROUP_MEMBER_NOT_FOUND);
-        }
-      }
+      request.setGroupMemberId(
+          normalizeToMemberIds(request.getGroupId(), request.getGroupMemberId()));
+    }
+    if (request.getFixedAssigneeId() != null) {
+      request.setFixedAssigneeId(
+          normalizeToMemberId(request.getGroupId(), request.getFixedAssigneeId()));
     }
 
     var created = taskAssignmentService.assignTaskManuallyOrRandomly(request);
     if (created == null || created.isEmpty()) return ResponseEntity.noContent().build();
     return ResponseEntity.ok(created.get(0));
   }
-
 
   // 할 일 상태 변경
   @PutMapping("/assignments/{assignmentId}")
@@ -306,6 +324,14 @@ public class TaskController {
 
     request.setRequesterId(user.getId());
 
+    // 대상자 단일/다중 정규화 (있으면)
+    if (request.getTargetId() != null) {
+      request.setTargetId(normalizeToMemberId(groupId, request.getTargetId()));
+    }
+    if (request.getTargetIds() != null && !request.getTargetIds().isEmpty()) {
+      request.setTargetIds(normalizeToMemberIds(groupId, request.getTargetIds()));
+    }
+
     var created = assignmentOverrideService.createOverrideRequests(assignmentId, request);
     return ResponseEntity.ok(created);
   }
@@ -323,7 +349,8 @@ public class TaskController {
 
     ensureMember(user.getId(), groupId);
 
-    request.setGroupMemberId(user.getId());
+    Long normalizedActorId = normalizeToMemberId(groupId, request.getActorMemberId());
+    request.setActorMemberId(normalizedActorId);
 
     var updated = assignmentOverrideService.respondToOverrideRequest(requestId, request);
     return ResponseEntity.ok(updated);

--- a/src/main/java/com/zero/cohousesever/tasks/dto/assignment/TaskAssignmentRequest.java
+++ b/src/main/java/com/zero/cohousesever/tasks/dto/assignment/TaskAssignmentRequest.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.tasks.dto.assignment;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,10 +16,24 @@ public class TaskAssignmentRequest {
   private Long templateId;
   private List<Long> groupMemberId;
 
-
-  // 랜덤 유지용 null이면 템플릿 randomEnabled를 따라감
   private Boolean randomEnabled;
+  private Long fixedAssigneeId;       // MANUAL 고정 배정자
 
-  // 수동 지정용 값이 오면 무조건 이 멤버로 배정 (그룹장만 사용)
-  private Long fixedAssigneeId;
+  // 구버전 키 수용
+  @JsonAlias("assigneeId")
+  private Long _compatAssigneeId;
+
+  @JsonAlias("candidateIds")
+  private List<Long> _compatCandidateIds;
+
+  @JsonAlias("assignType")
+  private String _compatAssignType; // 서버에선 안 써도 됨
+
+  // 게터에서 통합
+  public Long getFixedAssigneeId() {
+    return fixedAssigneeId != null ? fixedAssigneeId : _compatAssigneeId;
+  }
+  public List<Long> getGroupMemberId() {
+    return groupMemberId != null ? groupMemberId : _compatCandidateIds;
+  }
 }

--- a/src/main/java/com/zero/cohousesever/tasks/dto/override/AssignmentOverrideRequest.java
+++ b/src/main/java/com/zero/cohousesever/tasks/dto/override/AssignmentOverrideRequest.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.tasks.dto.override;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,8 +12,13 @@ import lombok.Setter;
 @Setter
 public class AssignmentOverrideRequest {
   private Long assignmentId;        // 필수
+
+  @JsonAlias({"receiverId"})
   private Long targetId;            // 단일 대상 or null인 경우 전체
+
+  @JsonAlias({"receiverIds"})
   private List<Long> targetIds;     // 여러 명 대상일 때 사용
+
   private Long requesterId;
   private Long swapAssignmentId; // 서로 변경용
 }

--- a/src/main/java/com/zero/cohousesever/tasks/dto/override/AssignmentOverrideStatusUpdateRequest.java
+++ b/src/main/java/com/zero/cohousesever/tasks/dto/override/AssignmentOverrideStatusUpdateRequest.java
@@ -13,6 +13,13 @@ import lombok.Setter;
 public class AssignmentOverrideStatusUpdateRequest {
   private OverrideStatus status; // ACCEPTED, REJECTED, PENDING
 
-  @JsonAlias("actorId")
-  private Long groupMemberId;
+  private Long actorMemberId;
+
+  // 정규화 전
+  @JsonAlias({"groupMemberId", "actorId"})
+  private Long _compatActorId;
+  public Long getActorMemberId() {
+    return actorMemberId != null ? actorMemberId : _compatActorId;
+  }
+
 }

--- a/src/main/java/com/zero/cohousesever/tasks/service/AssignmentOverrideService.java
+++ b/src/main/java/com/zero/cohousesever/tasks/service/AssignmentOverrideService.java
@@ -130,7 +130,7 @@ public class AssignmentOverrideService {
   // ========== 응답(수락/거절) ==========
   @Transactional
   public AssignmentOverrideResponse respondToOverrideRequest(Long requestId, AssignmentOverrideStatusUpdateRequest req) {
-    if (req.getGroupMemberId() == null || req.getStatus() == null)
+    if (req.getActorMemberId() == null || req.getStatus() == null)
       throw new CustomException(ErrorCode.INVALID_REQUEST);
 
     AssignmentOverride r = overrideRepository.findById(requestId)
@@ -142,7 +142,7 @@ public class AssignmentOverrideService {
     assertTodayOrFuture(a.getDate());
     assertRequested(r);
 
-    final Long actor = req.getGroupMemberId();
+    final Long actor = req.getActorMemberId();
     assertInSameGroup(a, actor);
 
     // ----- ACCEPT -----

--- a/src/main/java/com/zero/cohousesever/tasks/service/TaskAssignmentService.java
+++ b/src/main/java/com/zero/cohousesever/tasks/service/TaskAssignmentService.java
@@ -17,17 +17,21 @@ import com.zero.cohousesever.tasks.entity.enums.AssignmentStatus;
 import com.zero.cohousesever.tasks.repository.RepeatDayRepository;
 import com.zero.cohousesever.tasks.repository.TaskAssignmentRepository;
 import com.zero.cohousesever.tasks.repository.TaskTemplateRepository;
-
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAdjusters;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
-import java.util.stream.Collectors.*;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -43,17 +47,59 @@ public class TaskAssignmentService {
   private final GroupMemberRepository groupMemberRepository;
   private final TaskAssignmentHistoryService taskAssignmentHistoryService;
 
+  // 리더 확인
+  public void ensureLeader(Long memberId, Long groupId) {
+    if (!groupMemberRepository.existsByGroupIdAndMemberIdAndIsLeaderTrue(groupId, memberId)) {
+      throw new CustomException(ErrorCode.NOT_GROUP_LEADER);
+    }
+  }
+
+  // 그룹원 확인
+  public void ensureMember(Long memberId, Long groupId) {
+    if (!groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
+      throw new CustomException(ErrorCode.GROUP_MEMBER_NOT_FOUND);
+    }
+  }
+
+  // 멤버 정규화
+  public Long toMemberId(Long groupId, Long maybeMemberOrGroupMemberId) {
+    if (maybeMemberOrGroupMemberId == null) {
+      throw new CustomException(ErrorCode.INVALID_REQUEST);
+    }
+    // 이미 memberId인 경우
+    if (groupMemberRepository.existsByGroupIdAndMemberId(groupId, maybeMemberOrGroupMemberId)) {
+      return maybeMemberOrGroupMemberId;
+    }
+    // group_member.id → memberId 역매핑
+    return groupMemberRepository.findById(maybeMemberOrGroupMemberId)
+        .filter(gm -> gm.getGroup().getId().equals(groupId))
+        .map(gm -> gm.getMember().getId())
+        .orElseThrow(() -> new CustomException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+  }
+
+  public List<Long> toMemberIds(Long groupId, List<Long> ids) {
+    if (ids == null) {
+      return List.of();
+    }
+    return ids.stream().map(id -> toMemberId(groupId, id)).toList();
+  }
+
   /**
-   * 후보 중 '과거 배정 전무' 멤버를 1순위로,
-   * 그다음 '주간 부하(담당 템플릿 수) 최소' 기준 선택(동률 랜덤)
+   * 후보 중 '과거 배정 전무' 멤버를 1순위로, 그다음 '주간 부하(담당 템플릿 수) 최소' 기준 선택(동률 랜덤)
    */
-  private Long pickMemberByPriority(Long groupId, LocalDate weekFrom, LocalDate weekTo, List<Long> candidates) {
+  private Long pickMemberByPriority(Long groupId, LocalDate weekFrom, LocalDate weekTo,
+      List<Long> candidates) {
     // Tier 분리: 과거 배정 없음 / 있음
     List<Long> tier1 = new ArrayList<>();
     List<Long> tier2 = new ArrayList<>();
     for (Long c : candidates) {
-      boolean hasAnyHistory = taskAssignmentRepository.existsByTemplate_GroupIdAndGroupMemberId(groupId, c);
-      if (!hasAnyHistory) tier1.add(c); else tier2.add(c);
+      boolean hasAnyHistory = taskAssignmentRepository.existsByTemplate_GroupIdAndGroupMemberId(
+          groupId, c);
+      if (!hasAnyHistory) {
+        tier1.add(c);
+      } else {
+        tier2.add(c);
+      }
     }
     List<Long> pool = !tier1.isEmpty() ? tier1 : tier2;
 
@@ -64,7 +110,9 @@ public class TaskAssignmentService {
     Map<Long, Set<Long>> memberToTemplateSet = new HashMap<>();
     for (TaskAssignment a : weeklyAll) {
       Long mId = a.getGroupMemberId();
-      if (mId == null) continue;
+      if (mId == null) {
+        continue;
+      }
       memberToTemplateSet.computeIfAbsent(mId, k -> new HashSet<>()).add(a.getTemplate().getId());
     }
 
@@ -73,7 +121,9 @@ public class TaskAssignmentService {
     for (Long c : pool) {
       int load = memberToTemplateSet.getOrDefault(c, Collections.emptySet()).size();
       if (load < best) {
-        best = load; tied.clear(); tied.add(c);
+        best = load;
+        tied.clear();
+        tied.add(c);
       } else if (load == best) {
         tied.add(c);
       }
@@ -82,9 +132,8 @@ public class TaskAssignmentService {
   }
 
   /**
-   * 템플릿 반복요일 기준으로 "이번 주(일~토)" 배정 생성.
-   * - 수동 고정 배정: request.fixedAssigneeId가 있으면 해당 멤버로 강제 배정(그룹 소속 검증)
-   * - 랜덤/직전담당자 유지: request.randomEnabled가 null이면 템플릿 설정(randomEnabled) 사용
+   * 템플릿 반복요일 기준으로 "이번 주(일~토)" 배정 생성. - 수동 고정 배정: request.fixedAssigneeId가 있으면 해당 멤버로 강제 배정(그룹 소속
+   * 검증) - 랜덤/직전담당자 유지: request.randomEnabled가 null이면 템플릿 설정(randomEnabled) 사용
    */
   public List<TaskAssignmentResponse> assignTaskManuallyOrRandomly(TaskAssignmentRequest req) {
     // 0) 기본 검증
@@ -119,9 +168,9 @@ public class TaskAssignmentService {
     } catch (DateTimeParseException e) {
       throw new CustomException(ErrorCode.DATE_FORMAT_INVALID);
     }
-    LocalDate sunday   = input.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+    LocalDate sunday = input.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
     LocalDate weekFrom = sunday;
-    LocalDate weekTo   = sunday.plusDays(6);
+    LocalDate weekTo = sunday.plusDays(6);
 
     // 4 이번 주 중복 날짜 Skip
     Set<LocalDate> alreadyInWeek = taskAssignmentRepository
@@ -136,7 +185,8 @@ public class TaskAssignmentService {
     // 5-1) 수동 고정 배정이 온 경우: 그룹 소속 검증 후 그대로 사용
     if (req.getFixedAssigneeId() != null) {
       Long fixed = req.getFixedAssigneeId();
-      boolean memberOfGroup = groupMemberRepository.existsByGroupIdAndMemberId(req.getGroupId(), fixed);
+      boolean memberOfGroup = groupMemberRepository.existsByGroupIdAndMemberId(req.getGroupId(),
+          fixed);
       if (!memberOfGroup) {
         throw new CustomException(ErrorCode.OVERRIDE_NOT_SAME_GROUP);
       }
@@ -144,7 +194,8 @@ public class TaskAssignmentService {
 
     } else {
       // 5-2) 자동 선택(랜덤/직전담당자 유지)
-      boolean random = (req.getRandomEnabled() != null) ? req.getRandomEnabled() : template.isRandomEnabled();
+      boolean random =
+          (req.getRandomEnabled() != null) ? req.getRandomEnabled() : template.isRandomEnabled();
 
       if (random) {
         pickedMemberId = pickMemberByPriority(req.getGroupId(), weekFrom, weekTo, candidateIds);
@@ -164,7 +215,9 @@ public class TaskAssignmentService {
     List<TaskAssignment> toSave = new ArrayList<>();
     for (RepeatDay rd : days) {
       LocalDate d = sunday.plusDays(rd.getDayOfWeek().getValue() % 7); // SUNDAY=0
-      if (alreadyInWeek.contains(d)) continue;
+      if (alreadyInWeek.contains(d)) {
+        continue;
+      }
       toSave.add(TaskAssignment.builder()
           .template(template)
           .groupMemberId(pickedMemberId)
@@ -172,8 +225,13 @@ public class TaskAssignmentService {
           .build());
     }
 
-    if (toSave.isEmpty()) return List.of();
-    return TaskAssignmentResponse.fromAll(taskAssignmentRepository.saveAll(toSave));
+    if (toSave.isEmpty()) {
+      return List.of();
+    }
+    var saved = taskAssignmentRepository.saveAll(toSave);
+    return saved.stream()
+        .map(a -> TaskAssignmentResponse.from(a, "WEEKLY"))
+        .toList();
   }
 
   /**
@@ -184,12 +242,20 @@ public class TaskAssignmentService {
       LocalDate sun = LocalDate.now(KST).with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
       return new LocalDate[]{sun, sun.plusDays(6)};
     }
-    if (from == null) from = to;
-    if (to == null)   to   = from;
-    if (to.isBefore(from)) { LocalDate tmp = from; from = to; to = tmp; }
+    if (from == null) {
+      from = to;
+    }
+    if (to == null) {
+      to = from;
+    }
+    if (to.isBefore(from)) {
+      LocalDate tmp = from;
+      from = to;
+      to = tmp;
+    }
 
     LocalDate start = from.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
-    LocalDate end   = to.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+    LocalDate end = to.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
     return new LocalDate[]{start, end};
   }
 
@@ -197,7 +263,9 @@ public class TaskAssignmentService {
    * 할 일 상태변경(이행여부) + repeatType 포함 응답
    */
   public TaskAssignmentResponse updateAssignmentStatus(Long assignmentId, AssignmentStatus status) {
-    if (status == null) throw new CustomException(ErrorCode.ASSIGNMENT_STATUS_REQUIRED);
+    if (status == null) {
+      throw new CustomException(ErrorCode.ASSIGNMENT_STATUS_REQUIRED);
+    }
 
     TaskAssignment a = taskAssignmentRepository.findById(assignmentId)
         .orElseThrow(() -> new CustomException(ErrorCode.TASK_ASSIGNMENT_NOT_FOUND));
@@ -208,7 +276,9 @@ public class TaskAssignmentService {
     // 히스토리 기록 추가
     taskAssignmentHistoryService.recordStatusChange(saved);
 
-    String repeatType = repeatDayRepository.existsByTaskTemplate_Id(saved.getTemplate().getId()) ? "WEEKLY" : "NONE";
+    String repeatType =
+        repeatDayRepository.existsByTaskTemplate_Id(saved.getTemplate().getId()) ? "WEEKLY"
+            : "NONE";
     return TaskAssignmentResponse.from(saved, repeatType);
   }
 
@@ -222,7 +292,9 @@ public class TaskAssignmentService {
   }
 
   public List<TaskAssignmentResponse> getUncompletedThisWeek(Long groupId, Long memberId) {
-    if (groupId == null) throw new CustomException(ErrorCode.GROUP_ID_REQUIRED);
+    if (groupId == null) {
+      throw new CustomException(ErrorCode.GROUP_ID_REQUIRED);
+    }
 
     LocalDate[] range = computeThisWeekRange();
     LocalDate start = range[0], end = range[1];
@@ -250,7 +322,9 @@ public class TaskAssignmentService {
 
   // 이번 주 미이행을 '담당자별'로 묶어서 반환
   public List<UncompletedByMemberResponse> getUncompletedThisWeekByMember(Long groupId) {
-    if (groupId == null) throw new CustomException(ErrorCode.GROUP_ID_REQUIRED);
+    if (groupId == null) {
+      throw new CustomException(ErrorCode.GROUP_ID_REQUIRED);
+    }
 
     LocalDate[] range = computeThisWeekRange();
     LocalDate start = range[0], end = range[1];
@@ -271,7 +345,8 @@ public class TaskAssignmentService {
             .thenComparing(TaskAssignment::getId))
         .map(a -> TaskAssignmentResponse.from(
             a, weeklyTemplateIds.contains(a.getTemplate().getId()) ? "WEEKLY" : "NONE"))
-        .collect(groupingBy(TaskAssignmentResponse::getGroupMemberId, LinkedHashMap::new, toList()));
+        .collect(
+            groupingBy(TaskAssignmentResponse::getGroupMemberId, LinkedHashMap::new, toList()));
 
     return grouped.entrySet().stream()
         .map(e -> UncompletedByMemberResponse.builder()
@@ -285,21 +360,22 @@ public class TaskAssignmentService {
   }
 
   /**
-   * 할일 배정 목록 조회 (최소 단위: 주)
-   * - from/to 없으면 이번 주(일~토)
-   * - 한쪽만 주어지면 그 날짜의 주(일~토)
-   * - 둘 다 주어지면: from의 일요일 ~ to의 토요일
-   * - memberId가 있으면 해당 멤버만, 없으면 전체
+   * 할일 배정 목록 조회 (최소 단위: 주) - from/to 없으면 이번 주(일~토) - 한쪽만 주어지면 그 날짜의 주(일~토) - 둘 다 주어지면: from의 일요일 ~
+   * to의 토요일 - memberId가 있으면 해당 멤버만, 없으면 전체
    */
-  public List<TaskAssignmentResponse> getAssignments(Long groupId, LocalDate from, LocalDate to, Long memberId) {
-    if (groupId == null) throw new CustomException(ErrorCode.GROUP_ID_REQUIRED);
+  public List<TaskAssignmentResponse> getAssignments(Long groupId, LocalDate from, LocalDate to,
+      Long memberId) {
+    if (groupId == null) {
+      throw new CustomException(ErrorCode.GROUP_ID_REQUIRED);
+    }
 
     LocalDate[] range = computeWeekRange(from, to);
     LocalDate start = range[0], end = range[1];
 
     List<TaskAssignment> list = (memberId == null)
         ? taskAssignmentRepository.findByTemplate_GroupIdAndDateBetween(groupId, start, end)
-        : taskAssignmentRepository.findByTemplate_GroupIdAndGroupMemberIdAndDateBetween(groupId, memberId, start, end);
+        : taskAssignmentRepository.findByTemplate_GroupIdAndGroupMemberIdAndDateBetween(groupId,
+            memberId, start, end);
 
     Set<Long> templateIds = list.stream().map(a -> a.getTemplate().getId()).collect(toSet());
     Set<Long> weeklyTemplateIds = templateIds.isEmpty()
@@ -308,11 +384,13 @@ public class TaskAssignmentService {
 
     return list.stream()
         .sorted(Comparator
-            .comparing((TaskAssignment a) -> a.getDate().getDayOfWeek().getValue() % 7) // SUNDAY first
+            .comparing(
+                (TaskAssignment a) -> a.getDate().getDayOfWeek().getValue() % 7) // SUNDAY first
             .thenComparing(TaskAssignment::getDate)
             .thenComparing(TaskAssignment::getId))
         .map(a -> {
-          String repeatType = weeklyTemplateIds.contains(a.getTemplate().getId()) ? "WEEKLY" : "NONE";
+          String repeatType =
+              weeklyTemplateIds.contains(a.getTemplate().getId()) ? "WEEKLY" : "NONE";
           return TaskAssignmentResponse.from(a, repeatType);
         })
         .collect(toList());

--- a/src/test/java/com/zero/cohousesever/tasks/service/AssignmentOverrideServiceHistoryTest.java
+++ b/src/test/java/com/zero/cohousesever/tasks/service/AssignmentOverrideServiceHistoryTest.java
@@ -70,7 +70,7 @@ class AssignmentOverrideServiceHistoryTest {
         .thenReturn(2);
 
     AssignmentOverrideStatusUpdateRequest accept = new AssignmentOverrideStatusUpdateRequest();
-    accept.setGroupMemberId(202L);
+    accept.setActorMemberId(202L);
     accept.setStatus(OverrideStatus.ACCEPTED);
 
     var res = service.respondToOverrideRequest(55L, accept);
@@ -131,7 +131,7 @@ class AssignmentOverrideServiceHistoryTest {
 
     // 3) 202가 수락
     AssignmentOverrideStatusUpdateRequest accept = new AssignmentOverrideStatusUpdateRequest();
-    accept.setGroupMemberId(202L);
+    accept.setActorMemberId(202L);
     accept.setStatus(OverrideStatus.ACCEPTED);
 
     var res = service.respondToOverrideRequest(rowIdFor202, accept);

--- a/src/test/java/com/zero/cohousesever/tasks/service/AssignmentOverrideServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/tasks/service/AssignmentOverrideServiceTest.java
@@ -144,7 +144,7 @@ class AssignmentOverrideServiceTest {
         .thenReturn(2);
 
     AssignmentOverrideStatusUpdateRequest req = new AssignmentOverrideStatusUpdateRequest();
-    req.setGroupMemberId(actor);
+    req.setActorMemberId(actor);
     req.setStatus(OverrideStatus.ACCEPTED);
 
     AssignmentOverrideResponse res = service.respondToOverrideRequest(55L, req);
@@ -171,7 +171,7 @@ class AssignmentOverrideServiceTest {
         .thenReturn(2);
 
     AssignmentOverrideStatusUpdateRequest req = new AssignmentOverrideStatusUpdateRequest();
-    req.setGroupMemberId(202L);
+    req.setActorMemberId(202L);
     req.setStatus(OverrideStatus.ACCEPTED);
 
     AssignmentOverrideResponse res = service.respondToOverrideRequest(77L, req);
@@ -195,7 +195,7 @@ class AssignmentOverrideServiceTest {
     when(groupMemberRepo.existsByGroupIdAndMemberId(gid, actor)).thenReturn(true);
 
     AssignmentOverrideStatusUpdateRequest req = new AssignmentOverrideStatusUpdateRequest();
-    req.setGroupMemberId(actor);
+    req.setActorMemberId(actor);
     req.setStatus(OverrideStatus.REJECTED);
 
     CustomException ex = assertThrows(CustomException.class,
@@ -218,7 +218,7 @@ class AssignmentOverrideServiceTest {
         .thenReturn(List.of());
 
     AssignmentOverrideStatusUpdateRequest req = new AssignmentOverrideStatusUpdateRequest();
-    req.setGroupMemberId(target);
+    req.setActorMemberId(target);
     req.setStatus(OverrideStatus.REJECTED);
 
     AssignmentOverrideResponse res = service.respondToOverrideRequest(55L, req);


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
할 일 배정 담당자 변경 요청 memberId / groupMemberId 혼용 으로 인해 정규화 로직 추가
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
 - Controller
   - normalizeToMemberId, normalizeToMemberIds 추가
   - assignTask, requestOverride, respondOverride API에서 전달받은 ID를 정규화하여 memberId로 통일
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->

---

## Context
<!-- 변경이 발생한 배경/상황 -->
  - 같은 그룹원 비교 전부다 memberId로 체크
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
  - 코드 수정시 리팩토링, 변경 할 부분이 많아서 비교를 위한 정규화 로직 생성
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] TaskController에 ID 정규화 메서드(normalizeToMemberId, normalizeToMemberIds) 추가
- [변경 2] assignTask, requestOverride, respondOverride에서 요청 값 정규화 처리 적용
- [변경 3] 서비스 레이어는 오직 memberId 기준으로만 검증/처리하도록 통일

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
Closes #203 
<!-- ex: Closes #123 -->
