### PR TITLE
Feature: #178 - 비밀번호 재설정 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'software.amazon.awssdk:s3:2.20.0'
 
     // Tesseract Java 래퍼 라이브러리

--- a/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
+++ b/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
     REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
+    PASSWORD_RESET_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "비밀번호 재설정 토큰이 잘못되었거나 만료되었습니다."),
     MEMBER_STILL_IN_GROUP(HttpStatus.CONFLICT, "아직 그룹에 소속된 회원입니다."),
 
     // 그룹 관련 오류

--- a/src/main/java/com/zero/cohousesever/member/controller/AuthController.java
+++ b/src/main/java/com/zero/cohousesever/member/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.zero.cohousesever.member.dto.auth.*;
 import com.zero.cohousesever.member.security.CustomUserDetails;
 import com.zero.cohousesever.member.service.AuthService;
 import com.zero.cohousesever.member.service.MemberService;
+import com.zero.cohousesever.member.service.PasswordResetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,6 +18,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final MemberService memberService;
+    private final PasswordResetService passwordResetService;
 
     // 이메일 회원 가입
     @PostMapping("/signup")
@@ -75,6 +77,7 @@ public class AuthController {
     public ResponseEntity<MessageDto> sendPasswordResetEmail(
             @RequestBody PasswordForgotRequestDto requestDto
     ) {
+        passwordResetService.sendPasswordResetMail(requestDto);
 
         return ResponseEntity.ok().build();
     }
@@ -84,6 +87,7 @@ public class AuthController {
     public ResponseEntity<MessageDto> resetPassword(
             @RequestBody PasswordResetRequestDto requestDto
     ) {
+        passwordResetService.setNewPassword(requestDto);
 
         return ResponseEntity.ok().build();
     }
@@ -104,7 +108,6 @@ public class AuthController {
     public ResponseEntity<MessageDto> withdraw(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-
         Long memberId = userDetails.getId();
 
         memberService.deleteMember(memberId);

--- a/src/main/java/com/zero/cohousesever/member/entity/Member.java
+++ b/src/main/java/com/zero/cohousesever/member/entity/Member.java
@@ -40,6 +40,10 @@ public class Member extends BaseEntity {
     @Column(columnDefinition = "TINYINT")
     private Boolean gender; // 0: Male, 1: Female
 
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
     public void updateProfile(String name, LocalDate birthDate, Boolean gender) {
         this.name = name;
         this.birthDate = birthDate;

--- a/src/main/java/com/zero/cohousesever/member/repository/MemberRepository.java
+++ b/src/main/java/com/zero/cohousesever/member/repository/MemberRepository.java
@@ -12,6 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    Optional<Member> findByEmailAndNameAndStatus(String email, String name, MemberStatus status);
+
     boolean existsByEmail(String email);
 
     Optional<Member> findByIdAndStatus(Long memberId, MemberStatus memberStatus);

--- a/src/main/java/com/zero/cohousesever/member/service/PasswordResetService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/PasswordResetService.java
@@ -9,9 +9,10 @@ import com.zero.cohousesever.member.enums.MemberStatus;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -29,12 +30,14 @@ public class PasswordResetService {
     private static final int TOKEN_LENGTH = 32;
 
     private final MemberRepository memberRepository;
-    private final JavaMailSender mailSender;
+    private final MailSender mailSender;
     private final StringRedisTemplate redisTemplate;
     private final PasswordEncoder passwordEncoder;
     private final SecureRandom random = new SecureRandom();
 
+    @Value("${app.frontend.url}")
     private String frontendUrl;
+    @Value("${spring.mail.username}")
     private String senderEmail;
 
     public void sendPasswordResetMail(PasswordForgotRequestDto requestDto) {
@@ -76,28 +79,27 @@ public class PasswordResetService {
     }
 
     private void sendEmail(String email, String name, String token) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setFrom(senderEmail);
+        message.setSubject("[CoHouse] 비밀번호 재설정 안내");
+
+        String resetUrl = frontendUrl + "/reset-password?token=" + token;
+        String messageBody = String.format(
+                "안녕하세요 %s님,\n\n" +
+                        "비밀번호 재설정을 요청하셨습니다.\n" +
+                        "아래 링크를 클릭하여 비밀번호를 재설정해 주세요.\n\n" +
+                        "%s\n\n" +
+                        "이 링크는 30분 후에 만료됩니다.\n" +
+                        "본인이 요청하지 않았다면 이 이메일을 무시해 주세요.\n\n" +
+                        "감사합니다.\n" +
+                        "CoHouse 팀",
+                name, resetUrl
+        );
+        message.setText(messageBody);
+
         try {
-            SimpleMailMessage message = new SimpleMailMessage();
-            message.setTo(email);
-            message.setFrom(senderEmail);
-            message.setSubject("[CoHouse] 비밀번호 재설정 안내");
-
-            String resetUrl = frontendUrl + "/reset-password?token=" + token;
-            String messageBody = String.format(
-                    "안녕하세요 %s님,\n\n" +
-                            "비밀번호 재설정을 요청하셨습니다.\n" +
-                            "아래 링크를 클릭하여 비밀번호를 재설정해 주세요.\n\n" +
-                            "%s\n\n" +
-                            "이 링크는 30분 후에 만료됩니다.\n" +
-                            "본인이 요청하지 않았다면 이 이메일을 무시해 주세요.\n\n" +
-                            "감사합니다.\n" +
-                            "CoHouse 팀",
-                    name, resetUrl
-            );
-
-            message.setText(messageBody);
             mailSender.send(message);
-
         } catch (Exception e) {
             // 이메일 전송 실패시 로그만 남기고 진행
             log.error("비밀번호 재설정 이메일 전송 실패: {} - {}", email, e.getMessage());

--- a/src/main/java/com/zero/cohousesever/member/service/PasswordResetService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/PasswordResetService.java
@@ -86,14 +86,20 @@ public class PasswordResetService {
 
         String resetUrl = frontendUrl + "/reset-password?token=" + token;
         String messageBody = String.format(
-                "안녕하세요 %s님,\n\n" +
-                        "비밀번호 재설정을 요청하셨습니다.\n" +
-                        "아래 링크를 클릭하여 비밀번호를 재설정해 주세요.\n\n" +
-                        "%s\n\n" +
-                        "이 링크는 30분 후에 만료됩니다.\n" +
-                        "본인이 요청하지 않았다면 이 이메일을 무시해 주세요.\n\n" +
-                        "감사합니다.\n" +
-                        "CoHouse 팀",
+                """
+                        안녕하세요 %s님,
+                        
+                        비밀번호 재설정을 요청하셨습니다.
+                        아래 링크를 클릭하여 비밀번호를 재설정해 주세요.
+                        
+                        %s
+                        
+                        이 링크는 30분 후에 만료됩니다.
+                        본인이 요청하지 않았다면 이 이메일을 무시해 주세요.
+                        
+                        감사합니다.
+                        CoHouse 팀
+                        """,
                 name, resetUrl
         );
         message.setText(messageBody);

--- a/src/main/java/com/zero/cohousesever/member/service/PasswordResetService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/PasswordResetService.java
@@ -1,0 +1,106 @@
+package com.zero.cohousesever.member.service;
+
+import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.common.exception.ErrorCode;
+import com.zero.cohousesever.member.dto.auth.PasswordForgotRequestDto;
+import com.zero.cohousesever.member.dto.auth.PasswordResetRequestDto;
+import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.enums.MemberStatus;
+import com.zero.cohousesever.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    private static final String PASSWORD_RESET_KEY_PREFIX = "password_reset:";
+    private static final int TOKEN_EXPIRY_MINUTES = 30;
+    private static final int TOKEN_LENGTH = 32;
+
+    private final MemberRepository memberRepository;
+    private final JavaMailSender mailSender;
+    private final StringRedisTemplate redisTemplate;
+    private final PasswordEncoder passwordEncoder;
+    private final SecureRandom random = new SecureRandom();
+
+    private String frontendUrl;
+    private String senderEmail;
+
+    public void sendPasswordResetMail(PasswordForgotRequestDto requestDto) {
+        memberRepository.findByEmailAndNameAndStatus(requestDto.getEmail(), requestDto.getName(), MemberStatus.ACTIVE)
+                // 멤버가 존재하는 경우 이메일 발송
+                // 멤버가 존재하지 않으면 메일 발송하지 않고 그대로 리턴
+                .ifPresent(member -> {
+                    String token = generateToken();
+                    String redisKey = PASSWORD_RESET_KEY_PREFIX + token;
+                    redisTemplate.opsForValue().set(redisKey, member.getId().toString(), TOKEN_EXPIRY_MINUTES, TimeUnit.MINUTES);
+
+                    sendEmail(member.getEmail(), member.getName(), token);
+                });
+    }
+
+    public void setNewPassword(PasswordResetRequestDto requestDto) {
+        String redisKey = PASSWORD_RESET_KEY_PREFIX + requestDto.getToken();
+        String memberId = redisTemplate.opsForValue().get(redisKey);
+
+        if (memberId == null) {
+            throw new CustomException(ErrorCode.PASSWORD_RESET_TOKEN_INVALID);
+        }
+
+        Member member = memberRepository.findById(Long.valueOf(memberId))
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        member.updatePassword(passwordEncoder.encode(requestDto.getNewPassword()));
+        memberRepository.save(member);
+
+        redisTemplate.delete(redisKey);
+
+        log.info("비밀번호 재설정 완료: {}", member.getEmail());
+    }
+
+    private String generateToken() {
+        byte[] bytes = new byte[TOKEN_LENGTH];
+        random.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private void sendEmail(String email, String name, String token) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(email);
+            message.setFrom(senderEmail);
+            message.setSubject("[CoHouse] 비밀번호 재설정 안내");
+
+            String resetUrl = frontendUrl + "/reset-password?token=" + token;
+            String messageBody = String.format(
+                    "안녕하세요 %s님,\n\n" +
+                            "비밀번호 재설정을 요청하셨습니다.\n" +
+                            "아래 링크를 클릭하여 비밀번호를 재설정해 주세요.\n\n" +
+                            "%s\n\n" +
+                            "이 링크는 30분 후에 만료됩니다.\n" +
+                            "본인이 요청하지 않았다면 이 이메일을 무시해 주세요.\n\n" +
+                            "감사합니다.\n" +
+                            "CoHouse 팀",
+                    name, resetUrl
+            );
+
+            message.setText(messageBody);
+            mailSender.send(message);
+
+        } catch (Exception e) {
+            // 이메일 전송 실패시 로그만 남기고 진행
+            log.error("비밀번호 재설정 이메일 전송 실패: {} - {}", email, e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: ${MAIL_USERNAME:your-email@gmail.com}
-    password: ${MAIL_PASSWORD:your-app-password}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
     properties:
       mail:
         smtp:
@@ -37,4 +37,4 @@ cloud:
 
 app:
   frontend:
-    url: ${FRONTEND_URL:http://localhost:3000}
+    url: ${FRONTEND_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,11 @@ spring:
     enabled: true
     max-file-size: 1MB
     max-request-size: 1MB
-
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: your-email@gmail.com
+    password: your-password
 jwt:
   secret: ${JWT_SECRET}
   issuer: cohouse

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: ${MAIL_USERNAME}
-    password: ${MAIL_PASSWORD}
+    username: ${COHOUSE_MAIL_USERNAME}
+    password: ${COHOUSE_MAIL_PASSWORD}
     properties:
       mail:
         smtp:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,19 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: your-email@gmail.com
-    password: your-password
+    username: ${MAIL_USERNAME:your-email@gmail.com}
+    password: ${MAIL_PASSWORD:your-app-password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+
 jwt:
   secret: ${JWT_SECRET}
   issuer: cohouse
@@ -23,3 +34,7 @@ cloud:
   aws:
     region:
       static: ap-northeast-2
+
+app:
+  frontend:
+    url: ${FRONTEND_URL:http://localhost:3000}

--- a/src/test/java/com/zero/cohousesever/member/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/member/service/PasswordResetServiceTest.java
@@ -1,0 +1,252 @@
+package com.zero.cohousesever.member.service;
+
+import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.member.dto.auth.PasswordForgotRequestDto;
+import com.zero.cohousesever.member.dto.auth.PasswordResetRequestDto;
+import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.enums.MemberStatus;
+import com.zero.cohousesever.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.zero.cohousesever.common.exception.ErrorCode.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MailSender mailSender;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private PasswordResetService passwordResetService;
+
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 멤버 설정
+        testMember = Member.builder()
+                .name("테스트유저")
+                .email("test@example.com")
+                .password("encodedPassword")
+                .status(MemberStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(testMember, "id", 1L);
+
+        // Redis ValueOperations Mock 설정
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        // 설정값 주입
+        ReflectionTestUtils.setField(passwordResetService, "frontendUrl", "http://localhost:3000");
+        ReflectionTestUtils.setField(passwordResetService, "senderEmail", "noreply@cohouse.com");
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 이메일 발송 성공 - 유효한 이메일, 이름, 활성 상태")
+    void sendPasswordResetMail_Success() {
+        // given
+        PasswordForgotRequestDto passwordForgotRequestDto = new PasswordForgotRequestDto();
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "email", "test@example.com");
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "name", "테스트유저");
+
+        when(memberRepository.findByEmailAndNameAndStatus("test@example.com", "테스트유저", MemberStatus.ACTIVE))
+                .thenReturn(Optional.of(testMember));
+
+        // when
+        passwordResetService.sendPasswordResetMail(passwordForgotRequestDto);
+
+        // then
+        verify(memberRepository).findByEmailAndNameAndStatus("test@example.com", "테스트유저", MemberStatus.ACTIVE);
+        verify(valueOperations).set(startsWith("password_reset:"), eq("1"), eq(30L), eq(TimeUnit.MINUTES));
+        verify(mailSender).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 이메일 발송 - 존재하지 않는 멤버")
+    void sendPasswordResetMail_MemberNotFound() {
+        // given
+        PasswordForgotRequestDto passwordForgotRequestDto = new PasswordForgotRequestDto();
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "email", "none@example.com");
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "name", "존재하지 않는 유저");
+
+        when(memberRepository.findByEmailAndNameAndStatus("none@example.com", "존재하지 않는 유저", MemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        // when
+        passwordResetService.sendPasswordResetMail(passwordForgotRequestDto);
+
+        // then
+        verify(memberRepository).findByEmailAndNameAndStatus("none@example.com", "존재하지 않는 유저", MemberStatus.ACTIVE);
+        verify(valueOperations, never()).set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+        verify(mailSender, never()).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 이메일 발송 - 이름 불일치")
+    void sendPasswordResetMail_NameMismatch() {
+        // given
+        PasswordForgotRequestDto passwordForgotRequestDto = new PasswordForgotRequestDto();
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "email", "test@example.com");
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "name", "다른이름");
+
+        when(memberRepository.findByEmailAndNameAndStatus("test@example.com", "다른이름", MemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        // when
+        passwordResetService.sendPasswordResetMail(passwordForgotRequestDto);
+
+        // then
+        verify(memberRepository).findByEmailAndNameAndStatus("test@example.com", "다른이름", MemberStatus.ACTIVE);
+        verify(valueOperations, never()).set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+        verify(mailSender, never()).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 이메일 발송 - 비활성 멤버")
+    void sendPasswordResetMail_InactiveMember() {
+        // given
+        ReflectionTestUtils.setField(testMember, "status", MemberStatus.INACTIVE);
+
+        PasswordForgotRequestDto passwordForgotRequestDto = new PasswordForgotRequestDto();
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "email", "test@example.com");
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "name", "테스트유저");
+
+        when(memberRepository.findByEmailAndNameAndStatus("test@example.com", "테스트유저", MemberStatus.ACTIVE))
+                .thenReturn(Optional.empty()); // ACTIVE 상태가 아닌 경우 조회되지 않음
+
+        // when
+        passwordResetService.sendPasswordResetMail(passwordForgotRequestDto);
+
+        // then
+        verify(memberRepository).findByEmailAndNameAndStatus("test@example.com", "테스트유저", MemberStatus.ACTIVE);
+        verify(valueOperations, never()).set(anyString(), anyString(), anyLong(), any(TimeUnit.class));
+        verify(mailSender, never()).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 이메일 발송 - 이메일 전송 실패 시 예외 발생하지 않음")
+    void sendPasswordResetMail_EmailSendFailure() {
+        // given
+        PasswordForgotRequestDto passwordForgotRequestDto = new PasswordForgotRequestDto();
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "email", "test@example.com");
+        ReflectionTestUtils.setField(passwordForgotRequestDto, "name", "테스트유저");
+
+        when(memberRepository.findByEmailAndNameAndStatus("test@example.com", "테스트유저", MemberStatus.ACTIVE))
+                .thenReturn(Optional.of(testMember));
+        doThrow(new RuntimeException("Mail server error")).when(mailSender).send(any(SimpleMailMessage.class));
+
+        // when - 예외가 발생하지 않아야 함
+        passwordResetService.sendPasswordResetMail(passwordForgotRequestDto);
+
+        // then
+        verify(memberRepository).findByEmailAndNameAndStatus("test@example.com", "테스트유저", MemberStatus.ACTIVE);
+        verify(valueOperations).set(startsWith("password_reset:"), eq("1"), eq(30L), eq(TimeUnit.MINUTES));
+        verify(mailSender).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    @DisplayName("새 비밀번호 설정 성공")
+    void setNewPassword_Success() {
+        // given
+        String token = "validToken123";
+        String redisKey = "password_reset:" + token;
+
+        PasswordResetRequestDto passwordResetRequestDto = new PasswordResetRequestDto();
+        ReflectionTestUtils.setField(passwordResetRequestDto, "token", "validToken123");
+        ReflectionTestUtils.setField(passwordResetRequestDto, "newPassword", "newPassword123");
+
+        when(valueOperations.get(redisKey)).thenReturn("1");
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(testMember));
+        when(passwordEncoder.encode("newPassword123")).thenReturn("encodedNewPassword");
+
+        // when
+        passwordResetService.setNewPassword(passwordResetRequestDto);
+
+        // then
+        verify(valueOperations).get(redisKey);
+        verify(memberRepository).findById(1L);
+        verify(passwordEncoder).encode("newPassword123");
+        verify(memberRepository).save(testMember);
+        verify(redisTemplate).delete(redisKey);
+    }
+
+    @Test
+    @DisplayName("새 비밀번호 설정 실패 - 유효하지 않은 토큰")
+    void setNewPassword_InvalidToken() {
+        // given
+        String token = "invalidToken";
+        String redisKey = "password_reset:" + token;
+
+        PasswordResetRequestDto passwordResetRequestDto = new PasswordResetRequestDto();
+        ReflectionTestUtils.setField(passwordResetRequestDto, "token", token);
+        ReflectionTestUtils.setField(passwordResetRequestDto, "newPassword", "newPassword123");
+
+        when(valueOperations.get(redisKey)).thenReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> passwordResetService.setNewPassword(passwordResetRequestDto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(PASSWORD_RESET_TOKEN_INVALID.getMessage());
+
+        verify(valueOperations).get(redisKey);
+        verify(memberRepository, never()).findById(anyLong());
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(memberRepository, never()).save(any(Member.class));
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    @DisplayName("새 비밀번호 설정 실패 - 멤버 조회 실패")
+    void setNewPassword_MemberNotFound() {
+        // given
+        String token = "validToken123";
+        String redisKey = "password_reset:" + token;
+
+        PasswordResetRequestDto passwordResetRequestDto = new PasswordResetRequestDto();
+        ReflectionTestUtils.setField(passwordResetRequestDto, "token", "validToken123");
+        ReflectionTestUtils.setField(passwordResetRequestDto, "newPassword", "newPassword123");
+
+        when(valueOperations.get(redisKey)).thenReturn("999"); // 존재하지 않는 멤버 ID
+        when(memberRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> passwordResetService.setNewPassword(passwordResetRequestDto))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(MEMBER_NOT_FOUND.getMessage());
+
+        verify(valueOperations).get(redisKey);
+        verify(memberRepository).findById(999L);
+        verify(passwordEncoder, never()).encode(anyString());
+        verify(memberRepository, never()).save(any(Member.class));
+        verify(redisTemplate, never()).delete(anyString());
+    }
+}


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
비밀번호 재설정 메일을 보내고, 새로운 비밀번호로 재설정하는 기능 구현

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
- `spring-boot-starter-mail` 의존성 추가
- AuthController: `sendPasswordResetEmail`, `resetPassword` 메서드 구현
- PasswordResetService 추가: `sendPasswordResetMail`, `setNewPassword`

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->
API 명세에 따른 기능 구현

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->
- 비밀번호 재설정 메일 발송 요청시, 이메일 발송 성공/실패 여부를 사용자에게 알리지 않음
  - 이메일과 이름 검증 성공 여부를 이용해 사용자 정보를 탈취하는 경우 방지
- 비밀번호 재설정 완료한 경우의 로직은 단순화하여 로그만 남김
  - 추후 비밀번호 변경 기록, 장기간 비밀번호 미변경시 안내 등으로 확장 가능

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] build.gradle에 `spring-boot-starter-mail` 의존성 추가
- [변경 2] application.yml에 mail 관련 설정 추가
- [변경 3] AuthController에 `sendPasswordResetEmail`, `resetPassword` 메서드 구현
- [변경 4] PasswordResetService 추가

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->
JUnit 단위 테스트 통과
Postman으로 API 호출 테스트 완료

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->
이메일 발송용 구글 아이디, 비밀번호를 배포 서버 환경변수에 추가 필요
프론트엔드 url 추가 필요
코드 생성 로직의 경우 리팩토링 가능성 있음

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #178 