### PR TITLE
Refactor: #208 - 초대코드 로직 개선

### DIFF
--- a/src/main/java/com/zero/cohousesever/common/utils/RandomCodeGenerator.java
+++ b/src/main/java/com/zero/cohousesever/common/utils/RandomCodeGenerator.java
@@ -1,0 +1,23 @@
+package com.zero.cohousesever.common.utils;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+public class RandomCodeGenerator {
+
+    private static final SecureRandom random = new SecureRandom();
+
+    public String generateCode(int length) {
+        // length 길이의 base64 문자열을 뽑기 위한 바이트 수 최적화
+        int bytes = (int) Math.ceil(length * 6 / 8.0);
+        byte[] buf = new byte[bytes];
+        random.nextBytes(buf);
+
+        String s = Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+
+        return s.substring(0, length);
+    }
+}

--- a/src/main/java/com/zero/cohousesever/group/service/GroupService.java
+++ b/src/main/java/com/zero/cohousesever/group/service/GroupService.java
@@ -135,7 +135,7 @@ public class GroupService {
             throw new CustomException(NOT_GROUP_LEADER);
         }
 
-        String inviteCode = inviteCodeService.generateInviteCode(groupId);
+        String inviteCode = inviteCodeService.getInviteCodeByGroupId(groupId);
 
         return GroupInviteDto.builder()
                 .groupId(groupId)
@@ -189,7 +189,7 @@ public class GroupService {
 
         String code = requestDto.getInviteCode();
 
-        Long groupId = inviteCodeService.validateInviteCode(code);
+        Long groupId = inviteCodeService.getGroupIdByInviteCode(code);
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));

--- a/src/main/java/com/zero/cohousesever/group/service/InviteCodeService.java
+++ b/src/main/java/com/zero/cohousesever/group/service/InviteCodeService.java
@@ -2,41 +2,48 @@ package com.zero.cohousesever.group.service;
 
 import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
+import com.zero.cohousesever.common.utils.RandomCodeGenerator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.security.SecureRandom;
 import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class InviteCodeService {
 
-    // 혼동을 피하기 위해 I와 1, O와 0은 미사용
-    private static final String CHAR_POOL = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
     private static final String INVITE_CODE_KEY_PREFIX = "inviteCode:";
+    private static final String INVITE_GROUP_KEY_PREFIX = "inviteGroupId:";
     private static final int CODE_LENGTH = 8;
     private static final long EXPIRE_HOURS = 3;
 
     private final StringRedisTemplate redisTemplate;
-    private final SecureRandom random = new SecureRandom();
+    private final RandomCodeGenerator codeGenerator;
 
-    public String generateInviteCode(Long groupId) {
-        String code;
-        String redisKey;
+    public String getInviteCodeByGroupId(Long groupId) {
+        // 기존 코드가 있는지 조회
+        String redisGroupKey = INVITE_GROUP_KEY_PREFIX + groupId;
+        String existingCode = redisTemplate.opsForValue().get(redisGroupKey);
 
-        do {
-            code = generateCode();
-            redisKey = INVITE_CODE_KEY_PREFIX + code;
-        } while (Boolean.TRUE.equals(redisTemplate.hasKey(redisKey)));
+        // 기존 코드가 1시간 이상 남아있는 경우 TTL을 새로 갱신한 뒤 기존 코드 재사용
+        if (existingCode != null) {
+            String redisCodeKey = INVITE_CODE_KEY_PREFIX + existingCode;
+            Long ttl = redisTemplate.getExpire(redisCodeKey, TimeUnit.MINUTES);
 
-        redisTemplate.opsForValue().set(redisKey, groupId.toString(), EXPIRE_HOURS, TimeUnit.HOURS);
+            if (ttl != null && ttl >= 60) {
+                redisTemplate.expire(redisCodeKey, EXPIRE_HOURS, TimeUnit.HOURS);
+                redisTemplate.expire(redisGroupKey, EXPIRE_HOURS, TimeUnit.HOURS);
 
-        return code;
+                return existingCode;
+            }
+        }
+
+        // 기존 코드가 없거나 1시간 미만으로 남았다면 새로운 코드 발급
+        return generateInviteCode(groupId);
     }
 
-    public Long validateInviteCode(String code) {
+    public Long getGroupIdByInviteCode(String code) {
         String groupId = redisTemplate.opsForValue().get(INVITE_CODE_KEY_PREFIX + code);
         if (groupId == null) {
             throw new CustomException(ErrorCode.INVITE_CODE_INVALID);
@@ -45,14 +52,15 @@ public class InviteCodeService {
         return Long.valueOf(groupId);
     }
 
-    // 코드 생성기
-    private String generateCode() {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < CODE_LENGTH; i++) {
-            int index = random.nextInt(CHAR_POOL.length());
-            sb.append(CHAR_POOL.charAt(index));
-        }
+    private String generateInviteCode(Long groupId) {
+        String code = codeGenerator.generateCode(CODE_LENGTH);
+        String redisCodeKey = INVITE_CODE_KEY_PREFIX + code;
+        String redisGroupKey = INVITE_GROUP_KEY_PREFIX + groupId;
 
-        return sb.toString();
+        // 코드->그룹 매핑과 그룹->코드 매핑을 같이 저장
+        redisTemplate.opsForValue().set(redisCodeKey, groupId.toString(), EXPIRE_HOURS, TimeUnit.HOURS);
+        redisTemplate.opsForValue().set(redisGroupKey, code, EXPIRE_HOURS, TimeUnit.HOURS);
+
+        return code;
     }
 }

--- a/src/main/java/com/zero/cohousesever/member/service/PasswordResetService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/PasswordResetService.java
@@ -2,6 +2,7 @@ package com.zero.cohousesever.member.service;
 
 import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
+import com.zero.cohousesever.common.utils.RandomCodeGenerator;
 import com.zero.cohousesever.member.dto.auth.PasswordForgotRequestDto;
 import com.zero.cohousesever.member.dto.auth.PasswordResetRequestDto;
 import com.zero.cohousesever.member.entity.Member;
@@ -33,7 +34,7 @@ public class PasswordResetService {
     private final MailSender mailSender;
     private final StringRedisTemplate redisTemplate;
     private final PasswordEncoder passwordEncoder;
-    private final SecureRandom random = new SecureRandom();
+    private final RandomCodeGenerator codeGenerator;
 
     @Value("${app.frontend.url}")
     private String frontendUrl;
@@ -45,7 +46,7 @@ public class PasswordResetService {
                 // 멤버가 존재하는 경우 이메일 발송
                 // 멤버가 존재하지 않으면 메일 발송하지 않고 그대로 리턴
                 .ifPresent(member -> {
-                    String token = generateToken();
+                    String token = codeGenerator.generateCode(TOKEN_LENGTH);
                     String redisKey = PASSWORD_RESET_KEY_PREFIX + token;
                     redisTemplate.opsForValue().set(redisKey, member.getId().toString(), TOKEN_EXPIRY_MINUTES, TimeUnit.MINUTES);
 
@@ -70,12 +71,6 @@ public class PasswordResetService {
         redisTemplate.delete(redisKey);
 
         log.info("비밀번호 재설정 완료: {}", member.getEmail());
-    }
-
-    private String generateToken() {
-        byte[] bytes = new byte[TOKEN_LENGTH];
-        random.nextBytes(bytes);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 
     private void sendEmail(String email, String name, String token) {

--- a/src/test/java/com/zero/cohousesever/group/service/GroupServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/group/service/GroupServiceTest.java
@@ -367,7 +367,7 @@ class GroupServiceTest {
 
         when(groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId))
                 .thenReturn(Optional.of(testGroupMember));
-        when(inviteCodeService.generateInviteCode(groupId)).thenReturn("INVITE123");
+        when(inviteCodeService.getInviteCodeByGroupId(groupId)).thenReturn("INVITE123");
 
         // when
         GroupInviteDto result = groupService.groupInvite(memberId, groupId);
@@ -715,7 +715,7 @@ class GroupServiceTest {
         ReflectionTestUtils.setField(groupJoinDto, "inviteCode", inviteCode);
 
         when(groupMemberRepository.existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE)).thenReturn(false);
-        when(inviteCodeService.validateInviteCode(inviteCode)).thenReturn(1L);
+        when(inviteCodeService.getGroupIdByInviteCode(inviteCode)).thenReturn(1L);
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(newMember));
         when(groupRepository.findById(1L)).thenReturn(Optional.of(testGroup));
         when(groupRepository.save(any(Group.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -733,7 +733,7 @@ class GroupServiceTest {
         assertThat(result.getJoinedAt()).isNotNull();
 
         verify(groupMemberRepository).existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE);
-        verify(inviteCodeService).validateInviteCode(inviteCode);
+        verify(inviteCodeService).getGroupIdByInviteCode(inviteCode);
         verify(memberRepository).findById(memberId);
         verify(groupRepository).findById(1L);
         verify(groupRepository).save(any(Group.class));
@@ -756,7 +756,7 @@ class GroupServiceTest {
                 .hasMessageContaining(ALREADY_IN_GROUP.getMessage());
 
         verify(groupMemberRepository).existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE);
-        verify(inviteCodeService, never()).validateInviteCode(any());
+        verify(inviteCodeService, never()).getGroupIdByInviteCode(any());
         verify(memberRepository, never()).findById(any());
         verify(groupRepository, never()).findById(any());
         verify(groupRepository, never()).save(any(Group.class));
@@ -774,7 +774,7 @@ class GroupServiceTest {
         ReflectionTestUtils.setField(groupJoinDto, "inviteCode", invalidInviteCode);
 
         when(groupMemberRepository.existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE)).thenReturn(false);
-        when(inviteCodeService.validateInviteCode(invalidInviteCode))
+        when(inviteCodeService.getGroupIdByInviteCode(invalidInviteCode))
                 .thenThrow(new CustomException(INVITE_CODE_INVALID));
 
         // when & then
@@ -783,7 +783,7 @@ class GroupServiceTest {
                 .hasMessageContaining(INVITE_CODE_INVALID.getMessage());
 
         verify(groupMemberRepository).existsByMemberIdAndStatus(memberId, GroupMemberStatus.ACTIVE);
-        verify(inviteCodeService).validateInviteCode(invalidInviteCode);
+        verify(inviteCodeService).getGroupIdByInviteCode(invalidInviteCode);
         verify(memberRepository, never()).findById(any());
         verify(groupRepository, never()).findById(any());
         verify(groupRepository, never()).save(any(Group.class));

--- a/src/test/java/com/zero/cohousesever/group/service/InviteCodeServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/group/service/InviteCodeServiceTest.java
@@ -2,6 +2,7 @@ package com.zero.cohousesever.group.service;
 
 import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
+import com.zero.cohousesever.common.utils.RandomCodeGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,9 @@ class InviteCodeServiceTest {
     private StringRedisTemplate redisTemplate;
 
     @Mock
+    private RandomCodeGenerator codeGenerator;
+
+    @Mock
     private ValueOperations<String, String> valueOperations;
 
     @InjectMocks
@@ -37,33 +41,78 @@ class InviteCodeServiceTest {
     }
 
     @Test
-    @DisplayName("초대 코드 생성 성공 - 8자리 코드 생성 및 Redis 저장 확인")
-    void generateInviteCode_Success() {
+    @DisplayName("초대 코드 생성 성공 - 기존 코드가 존재하지 않는 경우")
+    void getInviteCode_Success_WithoutExistingCodeByGroupId() {
         // given
         Long groupId = 1L;
-        when(redisTemplate.hasKey(anyString())).thenReturn(false);
+        String code = "testcode";
+        when(redisTemplate.opsForValue().get("inviteGroupId:" + groupId)).thenReturn(null);
+        when(codeGenerator.generateCode(8)).thenReturn(code);
 
         // when
-        String code = inviteCodeService.generateInviteCode(groupId);
+        String result = inviteCodeService.getInviteCodeByGroupId(groupId);
 
         // then
-        assertThat(code).isNotNull();
-        assertThat(code.length()).isEqualTo(8); // 8자리 코드인지 검증
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(code);
 
-        verify(redisTemplate).hasKey("inviteCode:" + code);
         verify(valueOperations).set(eq("inviteCode:" + code), eq(groupId.toString()), eq(3L), eq(TimeUnit.HOURS));
+        verify(valueOperations).set(eq("inviteGroupId:" + groupId), eq(code), eq(3L), eq(TimeUnit.HOURS));
+    }
+
+    @Test
+    @DisplayName("초대 코드 생성 성공 - 기존 코드가 존재하고 1시간 이상 남은 경우")
+    void getInviteCode_Success_WithExistingCodeByGroupId() {
+        // given
+        Long groupId = 1L;
+        String code = "testcode";
+        when(redisTemplate.opsForValue().get("inviteGroupId:" + groupId)).thenReturn(code);
+        when(redisTemplate.getExpire("inviteCode:" + code, TimeUnit.MINUTES)).thenReturn(120L); // 2시간 남음
+
+        // when
+        String result = inviteCodeService.getInviteCodeByGroupId(groupId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(code);
+
+        verify(redisTemplate).expire(eq("inviteCode:" + code), eq(3L), eq(TimeUnit.HOURS));
+        verify(redisTemplate).expire(eq("inviteGroupId:" + groupId), eq(3L), eq(TimeUnit.HOURS));
+    }
+
+    @Test
+    @DisplayName("초대 코드 생성 성공 - 기존 코드가 존재하고 1시간 미만 남은 경우")
+    void getInviteCode_ByGroupId_Success_WithTtlUnder60() {
+        // given
+        Long groupId = 1L;
+        String code = "testcode";
+        when(redisTemplate.opsForValue().get("inviteGroupId:" + groupId)).thenReturn(code);
+        when(redisTemplate.getExpire("inviteCode:" + code, TimeUnit.MINUTES)).thenReturn(10L); // 10분 남음
+        when(codeGenerator.generateCode(8)).thenReturn(code);
+
+        // when
+        String result = inviteCodeService.getInviteCodeByGroupId(groupId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(code);
+
+        verify(redisTemplate, never()).expire(eq("inviteCode:" + code), eq(3L), eq(TimeUnit.HOURS));
+        verify(redisTemplate, never()).expire(eq("inviteGroupId:" + groupId), eq(3L), eq(TimeUnit.HOURS));
+        verify(valueOperations).set(eq("inviteCode:" + code), eq(groupId.toString()), eq(3L), eq(TimeUnit.HOURS));
+        verify(valueOperations).set(eq("inviteGroupId:" + groupId), eq(code), eq(3L), eq(TimeUnit.HOURS));
     }
 
     @Test
     @DisplayName("초대 코드 검증 성공 - 유효한 코드일 경우 groupId 반환")
-    void validateInviteCode_Success() {
+    void getGroupIdByInviteCode_Success() {
         // given
         String code = "ABCDEFGH";
         Long groupId = 1L;
         when(valueOperations.get("inviteCode:" + code)).thenReturn(groupId.toString());
 
         // when
-        Long result = inviteCodeService.validateInviteCode(code);
+        Long result = inviteCodeService.getGroupIdByInviteCode(code);
 
         // then
         assertThat(result).isEqualTo(groupId);
@@ -72,37 +121,16 @@ class InviteCodeServiceTest {
 
     @Test
     @DisplayName("초대 코드 검증 실패 - 잘못된 코드일 경우 예외 발생")
-    void validateInviteCode_ThrowsException_WhenInvalid() {
+    void getGroupIdByInviteCode_ThrowsException_WhenInvalid() {
         // given
         String code = "INVALID";
         when(valueOperations.get("inviteCode:" + code)).thenReturn(null);
 
         // when & then
-        assertThatThrownBy(() -> inviteCodeService.validateInviteCode(code))
+        assertThatThrownBy(() -> inviteCodeService.getGroupIdByInviteCode(code))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.INVITE_CODE_INVALID.getMessage());
 
         verify(valueOperations).get("inviteCode:" + code);
-    }
-
-    @Test
-    @DisplayName("초대 코드 생성 시 중복 코드가 있으면 새로운 코드로 재생성된다")
-    void generateInviteCode_withCollision() {
-        // given
-        Long groupId = 1L;
-
-        // 첫 번째 hasKey 호출 → true (충돌 발생), 두 번째 → false (정상)
-        when(redisTemplate.hasKey(anyString()))
-                .thenReturn(true)   // 첫 번째 시도 충돌
-                .thenReturn(false); // 두 번째 시도 성공
-
-        // when
-        String code = inviteCodeService.generateInviteCode(groupId);
-
-        // then
-        assertThat(code).isNotNull();
-        verify(redisTemplate, times(2)).hasKey(anyString()); // 최소 2번 호출됨
-        verify(valueOperations, times(1))
-                .set(startsWith("inviteCode:"), eq(groupId.toString()), anyLong(), eq(TimeUnit.HOURS));
     }
 }

--- a/src/test/java/com/zero/cohousesever/member/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/member/service/PasswordResetServiceTest.java
@@ -1,6 +1,7 @@
 package com.zero.cohousesever.member.service;
 
 import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.common.utils.RandomCodeGenerator;
 import com.zero.cohousesever.member.dto.auth.PasswordForgotRequestDto;
 import com.zero.cohousesever.member.dto.auth.PasswordResetRequestDto;
 import com.zero.cohousesever.member.entity.Member;
@@ -42,6 +43,9 @@ class PasswordResetServiceTest {
 
     @Mock
     private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private RandomCodeGenerator codeGenerator;
 
     @Mock
     private PasswordEncoder passwordEncoder;


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
랜덤 코드 생성 로직과 초대코드 생성 방식 개선

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
- RandomCodeGenerator: 랜덤 코드 생성 로직 별도 분리 -> InviteCodeService, PasswordResetService에서 사용
- InviteCodeService: 기존에 저장된 초대코드가 있고 TTL이 1시간 이상 남은 경우 재사용

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->
안정적인 서비스 제공을 위한 코드 개선

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->
- 기존 로직은 사용자가 초대링크 생성 버튼을 여러 번 누를 경우 초대코드를 여러 개 생성해 저장하고 하나만 사용 가능한 문제가 있음
- 저장된 초대코드를 검사하고 기존 초대코드를 재사용하는 방식으로 변경하여 불필요한 초대코드 생성을 방지

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] RandomCodeGenerator 추가
- [변경 2] InviteCodeService, PasswordResetService - 코드 생성에 RandomCodeGenerator 사용
- [변경 3] InviteCodeService - 초대코드 생성하여 반환하는 로직 변경
- [변경 4] 테스트 코드 수정

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->
초대코드 갱신 정책에 대해 좋은 의견 있다면 제시해주세요.

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #208 