### PR TITLE
Refactor: #222 - 

### DIFF
--- a/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
+++ b/src/main/java/com/zero/cohousesever/common/exception/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     POST_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 게시글입니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "본인 게시글만 수정/삭제할 수 있습니다."),
     UNAUTHORIZED_ANNOUNCEMENT(HttpStatus.FORBIDDEN, "공지 작성 권한이 없습니다. (그룹장 전용)"),
+    POST_CREATE_FAILED(HttpStatus.NOT_FOUND, "게시글을 작성할 수 없습니다."),
 
     // 정산 관련 오류
     SETTLEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정산 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/zero/cohousesever/task/entity/AssignmentOverride.java
+++ b/src/main/java/com/zero/cohousesever/task/entity/AssignmentOverride.java
@@ -59,6 +59,9 @@ public class AssignmentOverride extends BaseEntity {
   @Column(nullable = false)
   private OverrideStatus status;
 
+  @Column(name = "post_id")
+  private Long postId;
+
   private LocalDateTime requestedAt;
   private LocalDateTime respondedAt;
 

--- a/src/main/java/com/zero/cohousesever/task/service/AssignmentOverrideService.java
+++ b/src/main/java/com/zero/cohousesever/task/service/AssignmentOverrideService.java
@@ -4,6 +4,10 @@ import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.group.enums.GroupMemberStatus;
 import com.zero.cohousesever.group.repository.GroupMemberRepository;
+import com.zero.cohousesever.post.dto.post.PostRequest;
+import com.zero.cohousesever.post.dto.post.PostResponse;
+import com.zero.cohousesever.post.service.PostService;
+import com.zero.cohousesever.post.type.PostType;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideRequest;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideResponse;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideStatusUpdateRequest;
@@ -13,12 +17,15 @@ import com.zero.cohousesever.task.entity.enums.OverrideStatus;
 import com.zero.cohousesever.task.repository.AssignmentOverrideRepository;
 import com.zero.cohousesever.task.repository.TaskAssignmentRepository;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -28,15 +35,16 @@ public class AssignmentOverrideService {
   private final TaskAssignmentRepository assignmentRepository;
   private final GroupMemberRepository groupMemberRepository;
   private final AssignmentOverrideHistoryService overrideHistoryService;
+  private final PostService postService;
 
-
-  @Value("${board.api.url:}")
-  private String boardApiUrl;
 
   // ========== 생성 (브로드캐스트 → 멤버별 요청 row 생성) ==========
   @Transactional
-  public List<AssignmentOverrideResponse> createOverrideRequests(Long assignmentId, AssignmentOverrideRequest req) {
-    if (req.getRequesterId() == null) throw new CustomException(ErrorCode.REQUESTER_ID_REQUIRED);
+  public List<AssignmentOverrideResponse> createOverrideRequests(Long assignmentId,
+      AssignmentOverrideRequest req) {
+    if (req.getRequesterId() == null) {
+      throw new CustomException(ErrorCode.REQUESTER_ID_REQUIRED);
+    }
 
     TaskAssignment a = assignmentRepository.findByIdForUpdate(assignmentId)
         .orElseThrow(() -> new CustomException(ErrorCode.TASK_ASSIGNMENT_NOT_FOUND));
@@ -56,7 +64,8 @@ public class AssignmentOverrideService {
       assertInSameGroup(a, targetId);
 
       // 이미 대상자에게 대기중이면 중복 생성 안 함
-      if (overrideRepository.existsByAssignment_IdAndTargetIdAndStatus(a.getId(), targetId, OverrideStatus.REQUESTED)) {
+      if (overrideRepository.existsByAssignment_IdAndTargetIdAndStatus(a.getId(), targetId,
+          OverrideStatus.REQUESTED)) {
         notifyBoard(a, req.getRequesterId(), Set.of(targetId), true);
         return List.of();
       }
@@ -80,8 +89,11 @@ public class AssignmentOverrideService {
 
     // 대상 미지정 → 그룹 ACTIVE 멤버 전체(요청자 제외)
     if (targets.isEmpty()) {
-      List<Long> members = groupMemberRepository.findMemberIdsByGroupIdAndStatus(groupId, GroupMemberStatus.ACTIVE);
-      if (members == null || members.isEmpty()) return List.of();
+      List<Long> members = groupMemberRepository.findMemberIdsByGroupIdAndStatus(groupId,
+          GroupMemberStatus.ACTIVE);
+      if (members == null || members.isEmpty()) {
+        return List.of();
+      }
 
       // 요청자 제외
       members.removeIf(m -> Objects.equals(m, req.getRequesterId()));
@@ -91,7 +103,8 @@ public class AssignmentOverrideService {
         // 같은 그룹 멤버만 허용
         assertInSameGroup(a, m);
         // 중복 대기요청은 스킵
-        if (overrideRepository.existsByAssignment_IdAndTargetIdAndStatus(a.getId(), m, OverrideStatus.REQUESTED)) {
+        if (overrideRepository.existsByAssignment_IdAndTargetIdAndStatus(a.getId(), m,
+            OverrideStatus.REQUESTED)) {
           continue;
         }
         created.add(overrideRepository.save(
@@ -111,7 +124,8 @@ public class AssignmentOverrideService {
     List<AssignmentOverride> created = new ArrayList<>();
     for (Long t : targets) {
       assertInSameGroup(a, t);
-      if (overrideRepository.existsByAssignment_IdAndTargetIdAndStatus(a.getId(), t, OverrideStatus.REQUESTED)) {
+      if (overrideRepository.existsByAssignment_IdAndTargetIdAndStatus(a.getId(), t,
+          OverrideStatus.REQUESTED)) {
         continue;
       }
       created.add(overrideRepository.save(
@@ -129,9 +143,11 @@ public class AssignmentOverrideService {
 
   // ========== 응답(수락/거절) ==========
   @Transactional
-  public AssignmentOverrideResponse respondToOverrideRequest(Long requestId, AssignmentOverrideStatusUpdateRequest req) {
-    if (req.getActorMemberId() == null || req.getStatus() == null)
+  public AssignmentOverrideResponse respondToOverrideRequest(Long requestId,
+      AssignmentOverrideStatusUpdateRequest req) {
+    if (req.getActorMemberId() == null || req.getStatus() == null) {
       throw new CustomException(ErrorCode.INVALID_REQUEST);
+    }
 
     AssignmentOverride r = overrideRepository.findById(requestId)
         .orElseThrow(() -> new CustomException(ErrorCode.OVERRIDE_REQUEST_NOT_FOUND));
@@ -152,7 +168,7 @@ public class AssignmentOverrideService {
         // 교착방지: ID 오름차순으로 락
         Long id1 = Math.min(a.getId(), r.getSwapAssignmentId());
         Long id2 = Math.max(a.getId(), r.getSwapAssignmentId());
-        TaskAssignment first  = assignmentRepository.findByIdForUpdate(id1)
+        TaskAssignment first = assignmentRepository.findByIdForUpdate(id1)
             .orElseThrow(() -> new CustomException(ErrorCode.TASK_ASSIGNMENT_NOT_FOUND));
         TaskAssignment second = assignmentRepository.findByIdForUpdate(id2)
             .orElseThrow(() -> new CustomException(ErrorCode.TASK_ASSIGNMENT_NOT_FOUND));
@@ -161,8 +177,9 @@ public class AssignmentOverrideService {
         assertTodayOrFuture(second.getDate());
         assertSameGroup(first, second);
 
-        if (!Objects.equals(r.getTargetId(), actor))
+        if (!Objects.equals(r.getTargetId(), actor)) {
           throw new CustomException(ErrorCode.OVERRIDE_ACCEPTOR_MUST_BE_TARGET);
+        }
 
         Long tmp = first.getGroupMemberId();
         first.setGroupMemberId(second.getGroupMemberId());
@@ -172,8 +189,10 @@ public class AssignmentOverrideService {
         r.setModifierId(actor);
 
         // 두 배정의 남은 대기요청 일괄 거절
-        overrideRepository.bulkUpdateStatusByAssignmentId(first.getId(),  OverrideStatus.REQUESTED, OverrideStatus.REJECTED, actor);
-        overrideRepository.bulkUpdateStatusByAssignmentId(second.getId(), OverrideStatus.REQUESTED, OverrideStatus.REJECTED, actor);
+        overrideRepository.bulkUpdateStatusByAssignmentId(first.getId(), OverrideStatus.REQUESTED,
+            OverrideStatus.REJECTED, actor);
+        overrideRepository.bulkUpdateStatusByAssignmentId(second.getId(), OverrideStatus.REQUESTED,
+            OverrideStatus.REJECTED, actor);
 
         // 히스토리 기록 추가
         overrideHistoryService.record(r, r.getTargetId(), actor, 0L);
@@ -182,8 +201,9 @@ public class AssignmentOverrideService {
       }
 
       // 일반(브로드캐스트 분해된) 지정요청: 대상자만 수락 가능
-      if (!Objects.equals(r.getTargetId(), actor))
+      if (!Objects.equals(r.getTargetId(), actor)) {
         throw new CustomException(ErrorCode.OVERRIDE_ACCEPTOR_MUST_BE_TARGET);
+      }
 
       // 담당자 변경
       a.setGroupMemberId(actor);
@@ -203,8 +223,9 @@ public class AssignmentOverrideService {
 
     // ----- REJECT -----
     // 대상자만 거절 가능
-    if (!Objects.equals(r.getTargetId(), actor))
+    if (!Objects.equals(r.getTargetId(), actor)) {
       throw new CustomException(ErrorCode.OVERRIDE_ACCEPTOR_MUST_BE_TARGET);
+    }
 
     r.setStatus(OverrideStatus.REJECTED);
     r.setModifierId(actor);
@@ -220,51 +241,76 @@ public class AssignmentOverrideService {
 
   // ===== Helpers =====
   private void assertTodayOrFuture(LocalDate date) {
-    if (date.isBefore(LocalDate.now()))
+    if (date.isBefore(LocalDate.now())) {
       throw new CustomException(ErrorCode.OVERRIDE_PAST_DATE_FORBIDDEN);
+    }
   }
 
   private void assertCurrentAssignee(TaskAssignment a, Long requesterId) {
-    if (!Objects.equals(a.getGroupMemberId(), requesterId))
+    if (!Objects.equals(a.getGroupMemberId(), requesterId)) {
       throw new CustomException(ErrorCode.OVERRIDE_REQUESTER_MUST_BE_ASSIGNEE);
+    }
   }
 
   private void assertRequested(AssignmentOverride r) {
-    if (r.getStatus() != OverrideStatus.REQUESTED)
+    if (r.getStatus() != OverrideStatus.REQUESTED) {
       throw new CustomException(ErrorCode.OVERRIDE_ALREADY_PROCESSED);
+    }
   }
 
   private Set<Long> collectTargets(AssignmentOverrideRequest req) {
     Set<Long> targets = new LinkedHashSet<>();
-    if (req.getTargetId() != null) targets.add(req.getTargetId());
-    if (req.getTargetIds() != null && !req.getTargetIds().isEmpty()) targets.addAll(req.getTargetIds());
+    if (req.getTargetId() != null) {
+      targets.add(req.getTargetId());
+    }
+    if (req.getTargetIds() != null && !req.getTargetIds().isEmpty()) {
+      targets.addAll(req.getTargetIds());
+    }
     return targets;
   }
 
-  private void notifyBoard(TaskAssignment a, Long requesterId, Set<Long> targets, boolean swap) {
-    if (boardApiUrl == null || boardApiUrl.isBlank()) return;
+  // 게시글 알림 작성
+  private Long notifyBoard(TaskAssignment a, Long requesterId, Set<Long> targets, boolean swap) {
     try {
       Long groupId = a.getTemplate().getGroupId();
-      String title = (swap ? "[서로 변경 요청] " : "[대신 해줄 사람 찾기] ") + a.getDate() + " 담당 교체 요청";
-      String content = "assignmentId=" + a.getId() + ", requester=" + requesterId + ", targets=" + targets;
-      Map<String, Object> payload = new HashMap<>();
-      payload.put("groupId", groupId);
-      payload.put("title", title);
-      payload.put("content", content);
-      new RestTemplate().postForObject(boardApiUrl + "/posts/auto", payload, Void.class);
-    } catch (Exception ignore) { }
+      String title = (swap ? "[서로 변경 요청] " : "[대신 해줄 사람 찾기] ")
+          + a.getDate() + " 담당 교체 요청";
+      String content = "assignmentId=" + a.getId()
+          + ", requester=" + requesterId
+          + ", targets=" + targets;
+
+      PostRequest req = PostRequest.builder()
+          .groupId(groupId)
+          .memberId(requesterId)
+          .type(PostType.FREE)
+          .title(title)
+          .content(content)
+          .build();
+
+      // PostService 내부 호출
+      PostResponse created = postService.createPost(req, requesterId);
+      return (created != null) ? created.getId() : null;
+
+    } catch (Exception e) {
+
+      throw new CustomException(ErrorCode.POST_CREATE_FAILED);
+    }
   }
+
 
   private void assertInSameGroup(TaskAssignment a, Long groupMemberId) {
     Long gid = a.getTemplate().getGroupId();
     boolean ok = groupMemberRepository.existsByGroupIdAndMemberId(gid, groupMemberId);
-    if (!ok) throw new CustomException(ErrorCode.OVERRIDE_NOT_SAME_GROUP);
+    if (!ok) {
+      throw new CustomException(ErrorCode.OVERRIDE_NOT_SAME_GROUP);
+    }
   }
 
   private void assertSameGroup(TaskAssignment a1, TaskAssignment a2) {
     Long g1 = a1.getTemplate().getGroupId();
     Long g2 = a2.getTemplate().getGroupId();
-    if (!Objects.equals(g1, g2))
+    if (!Objects.equals(g1, g2)) {
       throw new CustomException(ErrorCode.OVERRIDE_SWAP_DIFFERENT_GROUP);
+    }
   }
 }

--- a/src/test/java/com/zero/cohousesever/task/service/AssignmentOverrideServiceHistoryTest.java
+++ b/src/test/java/com/zero/cohousesever/task/service/AssignmentOverrideServiceHistoryTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.zero.cohousesever.group.enums.GroupMemberStatus;
 import com.zero.cohousesever.group.repository.GroupMemberRepository;
+import com.zero.cohousesever.post.service.PostService;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideRequest;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideResponse;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideStatusUpdateRequest;
@@ -30,7 +31,7 @@ class AssignmentOverrideServiceHistoryTest {
   @Mock TaskAssignmentRepository assignmentRepo;
   @Mock GroupMemberRepository groupMemberRepo;
   @Mock AssignmentOverrideHistoryService historyService;
-
+  @Mock PostService postService;
   @InjectMocks AssignmentOverrideService service;
 
   private TaskTemplate tpl(long tid, long gid) {
@@ -49,12 +50,6 @@ class AssignmentOverrideServiceHistoryTest {
         .assignment(a).requesterId(requester).targetId(target).status(OverrideStatus.REQUESTED).build();
     ReflectionTestUtils.setField(r, "id", id);
     return r;
-  }
-
-  @BeforeEach
-  void init() {
-    // 외부 게시판 알림 NO-OP
-    ReflectionTestUtils.setField(service, "boardApiUrl", "");
   }
 
   @Test

--- a/src/test/java/com/zero/cohousesever/task/service/AssignmentOverrideServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/task/service/AssignmentOverrideServiceTest.java
@@ -7,6 +7,9 @@ import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.group.enums.GroupMemberStatus;
 import com.zero.cohousesever.group.repository.GroupMemberRepository;
+import com.zero.cohousesever.post.dto.post.PostRequest;
+import com.zero.cohousesever.post.dto.post.PostResponse;
+import com.zero.cohousesever.post.service.PostService;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideRequest;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideResponse;
 import com.zero.cohousesever.task.dto.override.AssignmentOverrideStatusUpdateRequest;
@@ -16,12 +19,10 @@ import com.zero.cohousesever.task.entity.TaskTemplate;
 import com.zero.cohousesever.task.entity.enums.OverrideStatus;
 import com.zero.cohousesever.task.repository.AssignmentOverrideRepository;
 import com.zero.cohousesever.task.repository.TaskAssignmentRepository;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,9 +36,11 @@ class AssignmentOverrideServiceTest {
   @Mock AssignmentOverrideRepository overrideRepo;
   @Mock TaskAssignmentRepository assignmentRepo;
   @Mock GroupMemberRepository groupMemberRepo;
+  @Mock PostService postService;
+
+  @Mock AssignmentOverrideHistoryService overrideHistoryService;
 
   @InjectMocks AssignmentOverrideService service;
-  @Mock AssignmentOverrideHistoryService overrideHistoryService;
 
   private TaskTemplate tpl(long tid, long gid) {
     TaskTemplate t = TaskTemplate.builder().groupId(gid).build();
@@ -66,12 +69,6 @@ class AssignmentOverrideServiceTest {
     return r;
   }
 
-  @BeforeEach
-  void init() {
-    // 외부 게시판 알림 비활성(NO-OP)
-    ReflectionTestUtils.setField(service, "boardApiUrl", "");
-  }
-
   // ===== 생성: 대상 미지정 → 멤버별 요청 row 생성 =====
   @Test
   void create_noTarget_createsRequests_perActiveMembers_exceptRequester() {
@@ -84,7 +81,7 @@ class AssignmentOverrideServiceTest {
     when(groupMemberRepo.findMemberIdsByGroupIdAndStatus(gid, GroupMemberStatus.ACTIVE))
         .thenReturn(new java.util.ArrayList<>(List.of(101L, 201L, 202L, 203L)));
 
-    // ★ 소속 검증 스텁 추가: 요청자를 제외한 대상자 모두 true
+    // 소속 검증: 요청자/대상자 모두 true (실제 사용되는 대상자만 중요)
     when(groupMemberRepo.existsByGroupIdAndMemberId(eq(gid), anyLong())).thenAnswer(inv -> {
       Long memberId = inv.getArgument(1, Long.class);
       return Set.of(101L, 201L, 202L, 203L).contains(memberId);
@@ -109,7 +106,9 @@ class AssignmentOverrideServiceTest {
     // 요청자 제외 3명에게 생성
     assertEquals(3, out.size());
     assertTrue(out.stream().allMatch(r -> Set.of(201L, 202L, 203L).contains(r.getTargetId())));
-    verify(overrideRepo, atLeast(3)).save(any(AssignmentOverride.class));
+
+    // 게시판 글은 1번 생성 (브로드캐스트 전체에 대해 단일 알림글)
+    verify(postService, times(1)).createPost(any(PostRequest.class), eq(requester));
   }
 
   // ===== 생성: 지정 대상이 그룹 소속 아님 → 예외 =====
@@ -128,6 +127,9 @@ class AssignmentOverrideServiceTest {
     CustomException ex = assertThrows(CustomException.class,
         () -> service.createOverrideRequests(assignmentId, req));
     assertEquals(ErrorCode.OVERRIDE_NOT_SAME_GROUP, ex.getErrorCode());
+
+    // 실패 경로에서는 게시판 호출 없어야 함
+    verify(postService, never()).createPost(any(), anyLong());
   }
 
   // ===== 응답: 지정요청 ACCEPT → 담당자 교체 + 나머지 일괄 REJECT =====
@@ -152,6 +154,9 @@ class AssignmentOverrideServiceTest {
     assertEquals(actor, a.getGroupMemberId());
     assertEquals(OverrideStatus.ACCEPTED, res.getStatus());
     verify(overrideRepo).bulkUpdateStatusByAssignmentId(assignmentId, OverrideStatus.REQUESTED, OverrideStatus.REJECTED, actor);
+
+    // 응답(수락) 로직에서 게시판을 따로 건드리지 않는다면 호출 없음
+    verifyNoInteractions(postService);
   }
 
   // ===== 응답: 스왑 ACCEPT → 두 배정 담당자 맞교환 + 양쪽 일괄 REJECT =====
@@ -181,6 +186,9 @@ class AssignmentOverrideServiceTest {
     assertEquals(101L, second.getGroupMemberId());
     verify(overrideRepo).bulkUpdateStatusByAssignmentId(1L, OverrideStatus.REQUESTED, OverrideStatus.REJECTED, 202L);
     verify(overrideRepo).bulkUpdateStatusByAssignmentId(2L, OverrideStatus.REQUESTED, OverrideStatus.REJECTED, 202L);
+
+    // 응답 단계에서 게시판 미사용 가정
+    verifyNoInteractions(postService);
   }
 
   // ===== 응답: 지정요청 REJECT - 대상자 아님 → 금지 =====
@@ -201,6 +209,8 @@ class AssignmentOverrideServiceTest {
     CustomException ex = assertThrows(CustomException.class,
         () -> service.respondToOverrideRequest(55L, req));
     assertEquals(ErrorCode.OVERRIDE_ACCEPTOR_MUST_BE_TARGET, ex.getErrorCode());
+
+    verifyNoInteractions(postService);
   }
 
   // ===== 응답: 지정요청 REJECT - 대상자 본인 → 성공, 남은 REQUESTED 없으면 '모두 거절' 상태 =====
@@ -213,7 +223,7 @@ class AssignmentOverrideServiceTest {
     when(overrideRepo.findById(55L)).thenReturn(Optional.of(r));
     when(assignmentRepo.findByIdForUpdate(assignmentId)).thenReturn(Optional.of(a));
     when(groupMemberRepo.existsByGroupIdAndMemberId(gid, target)).thenReturn(true);
-    // 남은 REQUESTED 없음  모두 거절 케이스
+    // 남은 REQUESTED 없음  → 모두 거절 케이스 도달
     when(overrideRepo.findAllByAssignment_IdAndStatus(assignmentId, OverrideStatus.REQUESTED))
         .thenReturn(List.of());
 
@@ -225,7 +235,8 @@ class AssignmentOverrideServiceTest {
 
     assertEquals(OverrideStatus.REJECTED, res.getStatus());
     assertEquals(target, res.getModifierId());
-    // 남은 요청 조회 수행됨(모두 거절 판단 지점 도달)
     verify(overrideRepo).findAllByAssignment_IdAndStatus(assignmentId, OverrideStatus.REQUESTED);
+
+    verifyNoInteractions(postService);
   }
 }


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
 - 할 일 변경 요청시 게시글 작성 코드 수정
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
   - AssignmentOverrideService.notifyBoard() 내부 PostService.createPost()로 수정
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->

---

## Context
<!-- 변경이 발생한 배경/상황 -->
  - 교환 요청을 전체에게 보낼 때만 글이 생성된다”는 기존 동작 → 요청할 때마다 글 생성 요구사항으로 변경
  - 게시글 API가 내부 서비스로 제공되므로 내부 호출 방식으로 통일 
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
  - 외부 URL 의존(board.api.url) 제거로 환경 의존성 축소 및 테스트 용이성 상승
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] AssignmentOverrideService에 PostService 주입 및 사용
- [변경 2] 예외 처리: 게시글 생성 실패 시 CustomException(ErrorCode.POST_NOT_FOUND) 던지도록 정리
- [변경 3] 스왑/지정/전체/다중 요청 모든 경로에서 notifyBoard() 호출로 모든 요청에 게시글 작성

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
 기존 테스트와 동일
 - PostService를 @Mock으로 주입하고, 게시글 생성 경로에서 Stubbing 추가
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
Closes #222 
<!-- ex: Closes #123 -->
