### PR TITLE
Fix: #240 - jwt 예외 응답시 500으로 반환되는 문제 수정

### DIFF
--- a/src/main/java/com/zero/cohousesever/common/config/SecurityConfig.java
+++ b/src/main/java/com/zero/cohousesever/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.zero.cohousesever.common.config;
 
 import com.zero.cohousesever.member.security.JwtAuthenticationFilter;
+import com.zero.cohousesever.member.security.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -43,7 +45,8 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/zero/cohousesever/member/security/JwtExceptionFilter.java
+++ b/src/main/java/com/zero/cohousesever/member/security/JwtExceptionFilter.java
@@ -1,0 +1,46 @@
+package com.zero.cohousesever.member.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zero.cohousesever.common.exception.CustomException;
+import com.zero.cohousesever.common.exception.ErrorResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            log.error("CustomException 발생", e);
+            setErrorResponse(e, response);
+        }
+    }
+
+    private void setErrorResponse(CustomException e, HttpServletResponse response) throws IOException {
+        response.setStatus(e.getStatus().value());
+        response.setContentType("application/json;charset=utf-8");
+
+        ErrorResponse error = new ErrorResponse(
+                e.getStatus().value(),
+                e.getMessage(),
+                LocalDateTime.now()
+        );
+        response.getWriter().write(objectMapper.writeValueAsString(error));
+    }
+}

--- a/src/main/java/com/zero/cohousesever/member/service/AuthService.java
+++ b/src/main/java/com/zero/cohousesever/member/service/AuthService.java
@@ -4,6 +4,7 @@ import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.member.dto.auth.*;
 import com.zero.cohousesever.member.entity.Member;
+import com.zero.cohousesever.member.enums.MemberStatus;
 import com.zero.cohousesever.member.enums.TokenValidationStatus;
 import com.zero.cohousesever.member.repository.MemberRepository;
 import com.zero.cohousesever.member.security.CustomUserDetails;
@@ -51,6 +52,10 @@ public class AuthService {
     public JwtTokenResponseDto loginAuthenticate(LoginRequestDto requestDto) {
         Member member = memberRepository.findByEmail(requestDto.getEmail())
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        if (MemberStatus.INACTIVE.equals(member.getStatus())) {
+            throw new CustomException(MEMBER_INACTIVE);
+        }
 
         if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())) {
             throw new CustomException(PASSWORD_NOT_MATCH);


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->
JWT 인증 예외 발생시 지정된 에러코드가 아닌 500 응답을 반환하는 문제 수정
(추가) 탈퇴한 회원이 로그인 가능한 문제 수정

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->
- JwtExceptionFilter: `JwtAuthenticationFilter`에서 발생하는 예외를 잡아 에러코드에 맞는 적절한 응답 반환
- SecurityConfig: `securityFilterChain`에 `JwtExceptionFilter`를 등록
- AuthService: `loginAuthenticate`에 탈퇴한 회원 검증 로직 추가

---

## Context
<!-- 변경이 발생한 배경/상황 -->
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->
버그 리포트

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->
- 예외처리에 사용하는 `GlobalExceptionHandler`는 컨트롤러 단에서 예외를 잡아 처리 -> 컨트롤러 진입 이전에 필터에서 발생하는 JWT 인증 오류는 해당 핸들러가 처리할 수 없음 
- 따라서 커스텀 예외가 처리되지 못하고 필터 단에서 예외가 역전파되어 최종적으로 500 응답을 반환하는 문제가 있었음
- 필터단에서 발생하는 `CustomException`을 잡아 처리하는 필터를 추가하여 문제를 해결

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] JwtExceptionFilter 추가
- [변경 2] `securityFilterChain`에 `JwtExceptionFilter` 등록
- [변경 3] AuthService의 `loginAuthenticate`에 탈퇴한 회원 검증 로직 추가

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->
Postman API 호출 테스트

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
<!-- ex: Closes #123 -->
Closes #240