### PR TITLE
Fix: #242 - 템플릿 삭제 수정 오류로 인한 수정

### DIFF
--- a/src/main/java/com/zero/cohousesever/task/controller/TaskController.java
+++ b/src/main/java/com/zero/cohousesever/task/controller/TaskController.java
@@ -101,7 +101,7 @@ public class TaskController {
     TaskTemplate t = taskTemplateService.getById(templateId); // 없으면 내부에서 예외
     taskAssignmentService.ensureLeader(user.getId(), t.getGroupId());
 
-    TaskTemplate updated = taskTemplateService.updateTemplate(templateId, request.getCategory());
+    TaskTemplate updated = taskTemplateService.updateTemplate(templateId, request);
     return ResponseEntity.ok(TaskTemplateResponse.from(updated));
   }
 

--- a/src/main/java/com/zero/cohousesever/task/dto/template/TaskTemplateUpdateRequest.java
+++ b/src/main/java/com/zero/cohousesever/task/dto/template/TaskTemplateUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.zero.cohousesever.task.dto.template;
 
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,9 +8,11 @@ import lombok.Setter;
 @Setter
 
 /**
- * PUT /tasks/templates/{template_id} 엔드포인트 처리 시 카테고리만 변경위해 사용
+ * PUT /tasks/templates/{template_id} 카테고리, 랜덤여부, 반복요일 수정 가능
  */
 public class TaskTemplateUpdateRequest {
   private String category;
+  private Boolean randomEnabled;
+  private List<String> repeatDays;
 }
 

--- a/src/main/java/com/zero/cohousesever/task/entity/TaskTemplate.java
+++ b/src/main/java/com/zero/cohousesever/task/entity/TaskTemplate.java
@@ -29,4 +29,8 @@ public class TaskTemplate extends BaseEntity {
   @Column(nullable = false)
   private boolean randomEnabled;
 
+  @Builder.Default
+  @Column(nullable = false)
+  private boolean active = true;
+
 }

--- a/src/main/java/com/zero/cohousesever/task/scheduler/TaskAssignmentScheduler.java
+++ b/src/main/java/com/zero/cohousesever/task/scheduler/TaskAssignmentScheduler.java
@@ -49,6 +49,7 @@ public class TaskAssignmentScheduler {
     LocalDate weekTo = sunday.plusDays(6);
 
     List<TaskTemplate> templates = taskTemplateRepository.findAll().stream()
+        .filter(TaskTemplate::isActive)
         .filter(t -> repeatDayRepository.existsByTaskTemplate_Id(t.getId()))
         .toList();
 

--- a/src/main/java/com/zero/cohousesever/task/service/RepeatDayService.java
+++ b/src/main/java/com/zero/cohousesever/task/service/RepeatDayService.java
@@ -12,6 +12,7 @@ import java.time.DayOfWeek;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 반복 요일 설정 관련 비즈니스 로직 처리
@@ -65,7 +66,7 @@ public class RepeatDayService {
   }
 
   /**
-   * 반복 요일 수정
+   * 반복 요일 수정 단일
    */
   public RepeatDayResponse updateRepeatDay(Long templateId, Long repeatDayId, RepeatDayRequest request) {
     TaskTemplate template = taskTemplateRepository.findById(templateId)
@@ -117,4 +118,46 @@ public class RepeatDayService {
     }
   }
 
+  // 일괄 수정
+  @Transactional
+  public void replaceRepeatDays(Long templateId, List<String> days) {
+    TaskTemplate template = taskTemplateRepository.findById(templateId)
+        .orElseThrow(() -> new CustomException(ErrorCode.TEMPLATE_NOT_FOUND));
+
+    // 1) 입력 파싱/검증
+    java.util.Set<java.time.DayOfWeek> target = new java.util.LinkedHashSet<>();
+    if (days != null) {
+      for (String raw : days) {
+        if (raw == null || raw.isBlank()) {
+          throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+        try {
+          target.add(java.time.DayOfWeek.valueOf(raw.trim().toUpperCase()));
+        } catch (IllegalArgumentException e) {
+          throw new CustomException(ErrorCode.DATE_FORMAT_INVALID);
+        }
+      }
+    }
+
+    // 2) 현재 상태 조회
+    java.util.List<RepeatDay> current = repeatDayRepository.findByTaskTemplate_Id(templateId);
+    java.util.Map<java.time.DayOfWeek, RepeatDay> byDow = new java.util.HashMap<>();
+    for (RepeatDay rd : current) byDow.put(rd.getDayOfWeek(), rd);
+
+    // 3) 삭제: 현재에 있지만 target에 없는 요일 제거
+    for (RepeatDay rd : current) {
+      if (!target.contains(rd.getDayOfWeek())) {
+        repeatDayRepository.delete(rd);
+      }
+    }
+
+    // 4) 추가: target에 있지만 현재에 없는 요일 추가
+    for (java.time.DayOfWeek dow : target) {
+      if (!byDow.containsKey(dow)) {
+        repeatDayRepository.save(
+            RepeatDay.builder().taskTemplate(template).dayOfWeek(dow).build()
+        );
+      }
+    }
+  }
 }

--- a/src/main/java/com/zero/cohousesever/task/service/TaskTemplateService.java
+++ b/src/main/java/com/zero/cohousesever/task/service/TaskTemplateService.java
@@ -3,11 +3,21 @@ package com.zero.cohousesever.task.service;
 import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.task.dto.repeat.RepeatDayRequest;
+import com.zero.cohousesever.task.dto.template.TaskTemplateUpdateRequest;
+import com.zero.cohousesever.task.entity.TaskAssignment;
 import com.zero.cohousesever.task.entity.TaskTemplate;
+import com.zero.cohousesever.task.entity.enums.AssignmentStatus;
+import com.zero.cohousesever.task.entity.enums.OverrideStatus;
+import com.zero.cohousesever.task.repository.AssignmentOverrideRepository;
+import com.zero.cohousesever.task.repository.TaskAssignmentRepository;
 import com.zero.cohousesever.task.repository.TaskTemplateRepository;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 할일 템플릿 생성 및 조회, 삭제 등 템플릿 관련 비즈니스 로직을 처리
@@ -19,12 +29,21 @@ public class TaskTemplateService {
 
   private final TaskTemplateRepository taskTemplateRepository;
   private final RepeatDayService repeatDayService;
+  private final TaskAssignmentRepository taskAssignmentRepository;
+  private final TaskAssignmentHistoryService taskAssignmentHistoryService;
+  private final AssignmentOverrideRepository assignmentOverrideRepository;
+  private final AssignmentOverrideHistoryService assignmentOverrideHistoryService;
+
+  private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+  private static final long SYSTEM_ACTOR = 0L;
 
   /**
    * 할일 템플릿 목록 조회
    */
   public List<TaskTemplate> getAllTemplates(Long groupId) {
-    return taskTemplateRepository.findByGroupId(groupId);
+    return taskTemplateRepository.findByGroupId(groupId).stream()
+        .filter(TaskTemplate::isActive)
+        .toList();
   }
 
   /**
@@ -36,6 +55,7 @@ public class TaskTemplateService {
             .groupId(groupId)
             .category(category)
             .randomEnabled(Boolean.TRUE.equals(randomEnabled))
+            .active(true)
             .build()
     );
 
@@ -50,23 +70,77 @@ public class TaskTemplateService {
   }
 
   /**
-   * 템플릿 카테고리 수정
+   * 템플릿 수정
    */
-  public TaskTemplate updateTemplate(Long templateId, String category) {
-    TaskTemplate template = taskTemplateRepository.findById(templateId)
+  public TaskTemplate updateTemplate(Long templateId, TaskTemplateUpdateRequest req) {
+    TaskTemplate t = taskTemplateRepository.findById(templateId)
         .orElseThrow(() -> new CustomException(ErrorCode.TEMPLATE_NOT_FOUND));
-    template.setCategory(category);
-    return taskTemplateRepository.save(template);
+
+    // 1) 카테고리 (옵션)
+    if (req.getCategory() != null && !req.getCategory().isBlank()) {
+      t.setCategory(req.getCategory().trim());
+    }
+
+    // 2) 랜덤 여부 (옵션)
+    if (req.getRandomEnabled() != null) {
+      t.setRandomEnabled(req.getRandomEnabled());
+    }
+
+    // 3) 반복요일 교체 (옵션)
+    if (req.getRepeatDays() != null) {
+      repeatDayService.replaceRepeatDays(templateId, req.getRepeatDays());
+    }
+
+    return taskTemplateRepository.save(t);
   }
 
   /**
-   * 템플릿 삭제
+   * 템플릿 삭제(비활성화)
    */
+  @Transactional
   public void deleteTemplate(Long templateId) {
-    if (!taskTemplateRepository.existsById(templateId)) {
-      throw new CustomException(ErrorCode.TEMPLATE_NOT_FOUND);
+    TaskTemplate t = taskTemplateRepository.findById(templateId)
+        .orElseThrow(() -> new CustomException(ErrorCode.TEMPLATE_NOT_FOUND));
+
+    // 소프트 삭제
+    t.setActive(false);
+    taskTemplateRepository.save(t);
+
+    // 오늘~1주 미완료 배정 SKIPPED 처리 + 히스토리
+    LocalDate today = LocalDate.now(KST);
+    LocalDate end = today.plusWeeks(1);
+    List<TaskAssignment> upcoming =
+        taskAssignmentRepository.findByTemplate_IdAndDateBetween(t.getId(), today, end);
+
+    List<TaskAssignment> changed = new ArrayList<>();
+    for (TaskAssignment a : upcoming) {
+      if (a.getStatus() == AssignmentStatus.COMPLETED) continue;
+
+      // 배정 상태 SKIPPED 처리
+      if (a.getStatus() != AssignmentStatus.SKIPPED) {
+        a.setStatus(AssignmentStatus.SKIPPED);
+        changed.add(a);
+      }
+
+      // 관련된 '대기 중' 교체 요청 모두 REJECTED 처리 + 히스토리 남김
+      var pendings = assignmentOverrideRepository
+          .findAllByAssignment_IdAndStatus(a.getId(), OverrideStatus.REQUESTED);
+
+      for (var r : pendings) {
+        r.setStatus(OverrideStatus.REJECTED);
+        r.setModifierId(SYSTEM_ACTOR);          // 누가 거절 처리했는지 표시(시스템/관리자)
+        assignmentOverrideRepository.save(r);
+
+        // 히스토리 기록
+        assignmentOverrideHistoryService.record(r, r.getTargetId(), SYSTEM_ACTOR, 0L);
+      }
+
     }
-    taskTemplateRepository.deleteById(templateId);
+
+    if (!changed.isEmpty()) {
+      taskAssignmentRepository.saveAll(changed);
+      changed.forEach(taskAssignmentHistoryService::recordStatusChange);
+    }
   }
 
   public TaskTemplate getById(Long id) {

--- a/src/test/java/com/zero/cohousesever/task/service/TaskTemplateServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/task/service/TaskTemplateServiceTest.java
@@ -1,41 +1,59 @@
 package com.zero.cohousesever.task.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.zero.cohousesever.common.exception.CustomException;
 import com.zero.cohousesever.common.exception.ErrorCode;
 import com.zero.cohousesever.task.dto.repeat.RepeatDayRequest;
+import com.zero.cohousesever.task.dto.template.TaskTemplateUpdateRequest;
 import com.zero.cohousesever.task.entity.TaskTemplate;
+import com.zero.cohousesever.task.repository.TaskAssignmentRepository;
 import com.zero.cohousesever.task.repository.TaskTemplateRepository;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TaskTemplateServiceTest {
 
-  @Mock TaskTemplateRepository taskTemplateRepository;
-  @Mock RepeatDayService repeatDayService;
-  @InjectMocks TaskTemplateService taskTemplateService;
+  @Mock
+  TaskTemplateRepository taskTemplateRepository;
+  @Mock
+  RepeatDayService repeatDayService;
+
+  @InjectMocks
+  TaskTemplateService taskTemplateService;
+
+  @Mock
+  TaskAssignmentRepository taskAssignmentRepository;
+  @Mock
+  TaskAssignmentHistoryService taskAssignmentHistoryService;
+
 
   @Test
-  @DisplayName("그룹별 템플릿 조회")
-  void getAllTemplates_byGroup() {
-    TaskTemplate t1 = TaskTemplate.builder().groupId(1L).category("CLEANING").build();
-    TaskTemplate t2 = TaskTemplate.builder().groupId(1L).category("TRASH").build();
-    when(taskTemplateRepository.findByGroupId(1L)).thenReturn(List.of(t1, t2));
+  @DisplayName("그룹별 템플릿 조회 - active=true만 반환")
+  void getAllTemplates_byGroup_filtersActive() {
+    TaskTemplate active = TaskTemplate.builder().groupId(1L).category("CLEANING").randomEnabled(true).active(true).build();
+    TaskTemplate inactive = TaskTemplate.builder().groupId(1L).category("TRASH").randomEnabled(false).active(false).build();
+    when(taskTemplateRepository.findByGroupId(1L)).thenReturn(List.of(active, inactive));
 
     List<TaskTemplate> list = taskTemplateService.getAllTemplates(1L);
 
-    assertThat(list).hasSize(2);
-    assertThat(list).extracting(TaskTemplate::getCategory)
-        .containsExactlyInAnyOrder("CLEANING", "TRASH");
+    assertThat(list).hasSize(1);
+    assertThat(list.get(0).getCategory()).isEqualTo("CLEANING");
     verify(taskTemplateRepository).findByGroupId(1L);
   }
 
@@ -59,7 +77,7 @@ class TaskTemplateServiceTest {
     assertThat(saved.isRandomEnabled()).isTrue();
 
     verify(repeatDayService, times(1))
-        .addRepeatDay(eq(100L), any(RepeatDayRequest.class));
+        .addRepeatDay(org.mockito.ArgumentMatchers.eq(100L), any(RepeatDayRequest.class));
   }
 
   @Test
@@ -72,52 +90,91 @@ class TaskTemplateServiceTest {
           return t;
         });
 
-    var days = java.util.Arrays.asList("SUNDAY", "TUESDAY", "FRIDAY");
+    var days = Arrays.asList("SUNDAY", "TUESDAY", "FRIDAY");
     TaskTemplate saved = taskTemplateService.createTemplate(10L, "CLEANING", days, false);
 
     assertThat(saved.getId()).isEqualTo(200L);
     assertThat(saved.isRandomEnabled()).isFalse();
     verify(repeatDayService, times(3))
-        .addRepeatDay(eq(200L), any(RepeatDayRequest.class));
+        .addRepeatDay(org.mockito.ArgumentMatchers.eq(200L), any(RepeatDayRequest.class));
   }
 
   @Test
-  @DisplayName("템플릿 수정 - 존재하면 카테고리 변경")
-  void updateTemplate_ok() {
-    TaskTemplate found = TaskTemplate.builder().groupId(1L).category("OLD").build();
-    ReflectionTestUtils.setField(found, "id", 123L);
-    when(taskTemplateRepository.findById(123L)).thenReturn(Optional.of(found));
+  @DisplayName("템플릿 수정 - 카테고리/랜덤/반복요일 세트 교체(옵션 필드만 반영)")
+  void updateTemplate_ok_partialFields() {
+    // given
+    Long templateId = 123L;
+    TaskTemplate found = TaskTemplate.builder().groupId(1L).category("OLD").randomEnabled(false).active(true).build();
+    ReflectionTestUtils.setField(found, "id", templateId);
+
+    when(taskTemplateRepository.findById(templateId)).thenReturn(Optional.of(found));
     when(taskTemplateRepository.save(found)).thenReturn(found);
 
-    TaskTemplate updated = taskTemplateService.updateTemplate(123L, "NEW");
+    TaskTemplateUpdateRequest req = new TaskTemplateUpdateRequest();
+    req.setCategory("NEW");
+    req.setRandomEnabled(true);
+    req.setRepeatDays(Arrays.asList("MONDAY", "WEDNESDAY"));
 
+    // when
+    TaskTemplate updated = taskTemplateService.updateTemplate(templateId, req);
+
+    // then
     assertThat(updated.getCategory()).isEqualTo("NEW");
+    assertThat(updated.isRandomEnabled()).isTrue();
+    verify(repeatDayService).replaceRepeatDays(templateId, Arrays.asList("MONDAY", "WEDNESDAY"));
     verify(taskTemplateRepository).save(found);
   }
 
   @Test
-  @DisplayName("템플릿 수정 - 없으면 CustomException(TEMPLATE_NOT_FOUND)")
+  @DisplayName("템플릿 수정 - 대상 없음 -> CustomException(TEMPLATE_NOT_FOUND)")
   void updateTemplate_notFound() {
-    when(taskTemplateRepository.findById(999L)).thenReturn(Optional.empty());
-    assertThatThrownBy(() -> taskTemplateService.updateTemplate(999L, "ANY"))
+    Long templateId = 999L;
+    when(taskTemplateRepository.findById(templateId)).thenReturn(Optional.empty());
+
+    TaskTemplateUpdateRequest req = new TaskTemplateUpdateRequest();
+    req.setCategory("ANY");
+
+    assertThatThrownBy(() -> taskTemplateService.updateTemplate(templateId, req))
         .isInstanceOf(CustomException.class)
         .extracting("errorCode").isEqualTo(ErrorCode.TEMPLATE_NOT_FOUND);
+
+    verify(taskTemplateRepository).findById(templateId);
+    verify(taskTemplateRepository, never()).save(any());
+    verify(repeatDayService, never()).replaceRepeatDays(org.mockito.ArgumentMatchers.anyLong(), any());
   }
 
   @Test
-  @DisplayName("템플릿 삭제 - 존재 확인 후 삭제")
+  @DisplayName("템플릿 삭제 - 소프트 삭제(active=false)로 저장")
   void deleteTemplate_ok() {
-    when(taskTemplateRepository.existsById(11L)).thenReturn(true);
-    taskTemplateService.deleteTemplate(11L);
-    verify(taskTemplateRepository).deleteById(11L);
+    Long templateId = 11L;
+    TaskTemplate found = TaskTemplate.builder()
+        .groupId(10L).category("CLEANING").randomEnabled(true).active(true)
+        .build();
+    ReflectionTestUtils.setField(found, "id", templateId);
+
+    when(taskTemplateRepository.findById(templateId)).thenReturn(Optional.of(found));
+
+    taskTemplateService.deleteTemplate(templateId);
+
+    verify(taskTemplateRepository).findById(templateId);
+    verify(taskTemplateRepository).save(org.mockito.ArgumentMatchers.argThat(t ->
+        t.getId().equals(templateId) && !t.isActive()
+    ));
+    verify(taskTemplateRepository, never()).deleteById(org.mockito.ArgumentMatchers.anyLong());
   }
 
   @Test
   @DisplayName("템플릿 삭제 - 없으면 CustomException(TEMPLATE_NOT_FOUND)")
   void deleteTemplate_notFound() {
-    when(taskTemplateRepository.existsById(77L)).thenReturn(false);
-    assertThatThrownBy(() -> taskTemplateService.deleteTemplate(77L))
+    Long templateId = 77L;
+    when(taskTemplateRepository.findById(templateId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> taskTemplateService.deleteTemplate(templateId))
         .isInstanceOf(CustomException.class)
         .extracting("errorCode").isEqualTo(ErrorCode.TEMPLATE_NOT_FOUND);
+
+    verify(taskTemplateRepository).findById(templateId);
+    verify(taskTemplateRepository, never()).save(any());
+    verify(taskTemplateRepository, never()).deleteById(any());
   }
 }


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
   - 할 일 배정후 템플릿 수정, 삭제 500에러로 인한 코드 수정
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
   - Controller
      - DELETE /api/tasks/templates/{id} 동작을 소프트 삭제로 변경하고, 미래 배정 및 대기 중 교체 요청도 안전하게 정리하도록 개선
   -  Service 
      - TaskTemplateService.deleteTemplate 소프트 삭제로 변경
      - TaskTemplateService.updateTemplate 랜덤 여부, 반복요일 일괄 교체 추가
      - RepeatDayService.replaceRepeatDays 반복요일 전체 교체 추가
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->

---

## Context
<!-- 변경이 발생한 배경/상황 -->
  - 반복배정을 멈추려면 그룹장이 템플릿을 삭제해야 하지만 히스토리 조회로 인한 소프트 삭제로 변경
  - 삭제 시 이번 주 남은 일정 자동 취소, 다음 주부터는 더 이상 배정되지 않아야 함
  - 삭제 시 담당자 변경 요청도 자동 취소
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
  - 기존 삭제 방식은 FK참조와 히스토리 기록을 위해 불가능 소프트 삭제로 과거 데이터 보존 + 미래 배정 중단
  - 삭제 시점 이후의 배정과 담당자 변경 요청 자동 취소
  - 기존에 템플릿 수정은 카테고리만 변경 가능했지만 편의성을 고려하여 반복요일, 랜덤유무 수정 추가
  - 기존 반복요일 교체는 1:1 교환 방식이라 전체 교환을 위해 replaceRepeatDays 추가
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1] TaskTemplateService.deleteTemplate 코드 수정 삭제시 오늘 ~ 1주 이내 배정자동 취소
- [변경 2] TaskTemplateService.updateTemplate 수정(기존에 카테고리만 변경에서 반복요일, 랜덤여부 변경추가)
- [변경 3] RepeatDayService.replaceRepeatDays 메서드 추가

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
  - 기존 테스트 유지
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
 Closes #242 
<!-- ex: Closes #123 -->
