### PR TITLE
Feature# 246 템플릿 삭제 후 재배정 오류 수정

### DIFF
--- a/src/main/java/com/zero/cohousesever/task/controller/TaskController.java
+++ b/src/main/java/com/zero/cohousesever/task/controller/TaskController.java
@@ -183,7 +183,8 @@ public class TaskController {
       @RequestParam Long groupId,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
-      @RequestParam(required = false) Long memberId
+      @RequestParam(required = false) Long memberId,
+      @RequestParam(required = false, defaultValue = "true") boolean todo
   ) {
     taskAssignmentService.ensureMember(user.getId(), groupId);
 
@@ -191,7 +192,7 @@ public class TaskController {
         !groupMemberRepository.existsByGroupIdAndMemberId(groupId, memberId)) {
       throw new CustomException(ErrorCode.GROUP_MEMBER_NOT_FOUND);
     }
-    return ResponseEntity.ok(taskAssignmentService.getAssignments(groupId, from, to, memberId));
+    return ResponseEntity.ok(taskAssignmentService.getAssignments(groupId, from, to, memberId, todo));
   }
 
   // 생성

--- a/src/main/java/com/zero/cohousesever/task/repository/TaskAssignmentRepository.java
+++ b/src/main/java/com/zero/cohousesever/task/repository/TaskAssignmentRepository.java
@@ -13,8 +13,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface TaskAssignmentRepository extends JpaRepository<TaskAssignment, Long> {
 
-  List<TaskAssignment> findByTemplate_Id(Long templateId);
-
   // develop에서 온 메서드 (주간 중복 체크 등 기간 필터)
   List<TaskAssignment> findByTemplate_IdAndDateBetween(
       Long templateId, LocalDate start, LocalDate end);
@@ -42,10 +40,13 @@ public interface TaskAssignmentRepository extends JpaRepository<TaskAssignment, 
   List<TaskAssignment> findByTemplate_GroupIdAndGroupMemberIdAndDateBetweenAndStatusNot(
       Long groupId, Long groupMemberId, LocalDate start, LocalDate end, AssignmentStatus status);
 
-  List<TaskAssignment> findByGroupMemberIdAndDate(Long memberId, LocalDate date);
-
-  boolean existsByGroupMemberIdAndDateAndStatusNot(Long memberId, LocalDate date,
-      AssignmentStatus status);
-
   Optional<TaskAssignment> findByTemplate_IdAndDate(Long templateId, LocalDate date);
+
+  // "해야할일" 조회용: SKIPPED 제외 + 활성 템플릿만 (템플릿 삭제 후 재 배정시 오류)
+  List<TaskAssignment> findByTemplate_GroupIdAndDateBetweenAndStatusNotAndTemplate_ActiveTrue(
+      Long groupId, LocalDate start, LocalDate end, AssignmentStatus status
+  );
+
+  List<TaskAssignment> findByTemplate_GroupIdAndGroupMemberIdAndDateBetweenAndStatusNotAndTemplate_ActiveTrue(
+      Long groupId, Long groupMemberId, LocalDate start, LocalDate end, AssignmentStatus status);
 }

--- a/src/main/java/com/zero/cohousesever/task/service/TaskAssignmentService.java
+++ b/src/main/java/com/zero/cohousesever/task/service/TaskAssignmentService.java
@@ -375,59 +375,46 @@ public class TaskAssignmentService {
    * 할일 배정 목록 조회 (최소 단위: 주) - from/to 없으면 이번 주(일~토) - 한쪽만 주어지면 그 날짜의 주(일~토) - 둘 다 주어지면: from의 일요일 ~
    * to의 토요일 - memberId가 있으면 해당 멤버만, 없으면 전체
    */
-  public List<TaskAssignmentResponse> getAssignments(Long groupId, LocalDate from, LocalDate to,
-      Long memberId) {
-    if (groupId == null) {
-      throw new CustomException(ErrorCode.GROUP_ID_REQUIRED);
-    }
+  public List<TaskAssignmentResponse> getAssignments(
+      Long groupId, LocalDate from, LocalDate to, Long memberId, boolean todoView) {
+
+    if (groupId == null) throw new CustomException(ErrorCode.GROUP_ID_REQUIRED);
 
     LocalDate[] range = computeWeekRange(from, to);
     LocalDate start = range[0], end = range[1];
 
-    List<TaskAssignment> list = (memberId == null)
-        ? taskAssignmentRepository.findByTemplate_GroupIdAndDateBetween(groupId, start, end)
-        : taskAssignmentRepository.findByTemplate_GroupIdAndGroupMemberIdAndDateBetween(groupId,
-            memberId, start, end);
+    List<TaskAssignment> list;
+    if (todoView) {
+      list = (memberId == null)
+          ? taskAssignmentRepository
+          .findByTemplate_GroupIdAndDateBetweenAndStatusNotAndTemplate_ActiveTrue(
+              groupId, start, end, AssignmentStatus.SKIPPED)
+          : taskAssignmentRepository
+              .findByTemplate_GroupIdAndGroupMemberIdAndDateBetweenAndStatusNotAndTemplate_ActiveTrue(
+                  groupId, memberId, start, end, AssignmentStatus.SKIPPED);
+    } else {
+      // 기존 조회(관리/일반 화면)
+      list = (memberId == null)
+          ? taskAssignmentRepository.findByTemplate_GroupIdAndDateBetween(groupId, start, end)
+          : taskAssignmentRepository.findByTemplate_GroupIdAndGroupMemberIdAndDateBetween(
+              groupId, memberId, start, end);
+    }
 
-    Set<Long> templateIds = list.stream().map(a -> a.getTemplate().getId()).collect(toSet());
+    // repeatType 계산은 그대로
+    Set<Long> templateIds = list.stream().map(a -> a.getTemplate().getId()).collect(java.util.stream.Collectors.toSet());
     Set<Long> weeklyTemplateIds = templateIds.isEmpty()
-        ? Collections.emptySet()
+        ? java.util.Collections.emptySet()
         : repeatDayRepository.findTemplateIdsHavingRepeat(templateIds);
 
     return list.stream()
         .sorted(Comparator
-            .comparing(
-                (TaskAssignment a) -> a.getDate().getDayOfWeek().getValue() % 7) // SUNDAY first
+            .comparing((TaskAssignment a) -> a.getDate().getDayOfWeek().getValue() % 7)
             .thenComparing(TaskAssignment::getDate)
             .thenComparing(TaskAssignment::getId))
-        .map(a -> {
-          String repeatType =
-              weeklyTemplateIds.contains(a.getTemplate().getId()) ? "WEEKLY" : "NONE";
-          return TaskAssignmentResponse.from(a, repeatType);
-        })
-        .collect(toList());
+        .map(a -> TaskAssignmentResponse.from(
+            a, weeklyTemplateIds.contains(a.getTemplate().getId()) ? "WEEKLY" : "NONE"))
+        .collect(java.util.stream.Collectors.toList());
   }
 
-  /**
-   * 오늘(로컬 KST 기준) 해당 멤버의 할일 목록
-   */
-  public List<TaskAssignment> getTodayAssignments(Long memberId) {
-    if (memberId == null) {
-      throw new CustomException(ErrorCode.INVALID_REQUEST);
-    }
-    return taskAssignmentRepository.findByGroupMemberIdAndDate(memberId, LocalDate.now(KST));
-  }
-
-  /**
-   * 오늘(로컬 KST 기준) 해당 멤버의 미완료 존재 여부
-   */
-  public boolean hasIncompleteToday(Long memberId) {
-    if (memberId == null) {
-      throw new CustomException(ErrorCode.INVALID_REQUEST);
-    }
-    return taskAssignmentRepository.existsByGroupMemberIdAndDateAndStatusNot(
-        memberId, LocalDate.now(KST), AssignmentStatus.COMPLETED
-    );
-  }
 
 }

--- a/src/test/java/com/zero/cohousesever/task/service/TaskAssignmentServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/task/service/TaskAssignmentServiceTest.java
@@ -193,7 +193,7 @@ class TaskAssignmentServiceTest {
     when(repeatRepo.findTemplateIdsHavingRepeat(Set.of(10L, 20L)))
         .thenReturn(Set.of(10L)); // 10만 WEEKLY
 
-    List<TaskAssignmentResponse> out = service.getAssignments(1L, from, to, 1L);
+    List<TaskAssignmentResponse> out = service.getAssignments(1L, from, to, 1L, false);
 
     assertEquals(2, out.size());
     assertEquals(1L, out.get(0).getAssignmentId());


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
    템플릿 삭제 후 재배정시 기존 배정 내역도 조회되는 오류 수정
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
   - Controller :  getAssignments()메서드 todo추가로 실질적으로 해야 할일 만 조회, 히스토리는 기존내용처럼 전체내용 기록
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->

---

## Context
<!-- 변경이 발생한 배경/상황 -->
  -  기존에 배정 후 쥐소 한 SKIPPED, 비활성 템플릿이 getAssignments엔트포인트로 조회시 전체 조회되는 오류발생
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
  - 삭제 후 재배정시 기존에 배정한 내역도 조회로 인한 UI 혼동
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1]
- [변경 2]
- [변경 3]

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
Closes #248 
<!-- ex: Closes #123 -->
