### PR TITLE
Fix: #250 템플릿 삭제 오류 재수정

### DIFF
--- a/src/main/java/com/zero/cohousesever/task/repository/TaskAssignmentHistoryRepository.java
+++ b/src/main/java/com/zero/cohousesever/task/repository/TaskAssignmentHistoryRepository.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.repository.query.Param;
@@ -33,4 +34,23 @@ public interface TaskAssignmentHistoryRepository extends JpaRepository<TaskAssig
       @Param("to")   java.time.LocalDate to
   );
 
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(value = """
+    INSERT INTO tasks_assignment_histories
+      (assignment_id, group_member_id, category, status, date, created_at, updated_at)
+    VALUES
+      (:assignmentId, :groupMemberId, :category, :status, :date, NOW(), NOW())
+    ON DUPLICATE KEY UPDATE
+      group_member_id = VALUES(group_member_id),
+      category       = VALUES(category),
+      status         = VALUES(status),
+      updated_at     = NOW()
+  """, nativeQuery = true)
+  void upsertHistory(
+      @Param("assignmentId") Long assignmentId,
+      @Param("groupMemberId") Long groupMemberId,
+      @Param("category") String category,
+      @Param("status") String status,
+      @Param("date") java.sql.Date date
+  );
 }

--- a/src/main/java/com/zero/cohousesever/task/service/TaskAssignmentHistoryService.java
+++ b/src/main/java/com/zero/cohousesever/task/service/TaskAssignmentHistoryService.java
@@ -2,12 +2,12 @@ package com.zero.cohousesever.task.service;
 
 import com.zero.cohousesever.task.dto.assignment.TaskAssignmentResponse;
 import com.zero.cohousesever.task.entity.TaskAssignment;
-import com.zero.cohousesever.task.entity.TaskAssignmentHistory;
 import com.zero.cohousesever.task.repository.TaskAssignmentHistoryRepository;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,19 +16,16 @@ public class TaskAssignmentHistoryService {
   private final TaskAssignmentHistoryRepository historyRepository;
 
   // 상태변경 시 upsert 기록
+
+  @Transactional
   public void recordStatusChange(TaskAssignment a) {
-    TaskAssignmentHistory h = historyRepository
-        .findByAssignmentIdAndDate(a.getId(), a.getDate())
-        .orElseGet(() -> TaskAssignmentHistory.builder()
-            .assignmentId(a.getId())
-            .date(a.getDate())
-            .build());
-
-    h.setGroupMemberId(a.getGroupMemberId());
-    h.setCategory(a.getTemplate().getCategory());
-    h.setStatus(a.getStatus());
-
-    historyRepository.save(h);
+    historyRepository.upsertHistory(
+        a.getId(),
+        a.getGroupMemberId(),
+        a.getTemplate().getCategory(),
+        a.getStatus().name(),
+        java.sql.Date.valueOf(a.getDate())
+    );
   }
 
   // 조회
@@ -46,19 +43,16 @@ public class TaskAssignmentHistoryService {
         .stream().map(TaskAssignmentResponse::fromHistory).toList();
   }
 
+  @Transactional
   public void recordCreatedAssignments(List<TaskAssignment> assignments) {
     for (TaskAssignment a : assignments) {
-      historyRepository.findByAssignmentIdAndDate(a.getId(), a.getDate())
-          .orElseGet(() -> {
-            TaskAssignmentHistory h = TaskAssignmentHistory.builder()
-                .assignmentId(a.getId())
-                .groupMemberId(a.getGroupMemberId())
-                .category(a.getTemplate().getCategory())
-                .status(a.getStatus()) // 보통 PENDING
-                .date(a.getDate())
-                .build();
-            return historyRepository.save(h);
-          });
+      historyRepository.upsertHistory(
+          a.getId(),
+          a.getGroupMemberId(),
+          a.getTemplate().getCategory(),
+          a.getStatus().name(),
+          java.sql.Date.valueOf(a.getDate())
+      );
     }
   }
 

--- a/src/test/java/com/zero/cohousesever/task/service/TaskAssignmentHistoryServiceTest.java
+++ b/src/test/java/com/zero/cohousesever/task/service/TaskAssignmentHistoryServiceTest.java
@@ -4,13 +4,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.zero.cohousesever.task.entity.TaskAssignment;
-import com.zero.cohousesever.task.entity.TaskAssignmentHistory;
 import com.zero.cohousesever.task.entity.TaskTemplate;
 import com.zero.cohousesever.task.entity.enums.AssignmentStatus;
 import com.zero.cohousesever.task.repository.RepeatDayRepository;
 import com.zero.cohousesever.task.repository.TaskAssignmentHistoryRepository;
 import com.zero.cohousesever.task.repository.TaskAssignmentRepository;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,50 +60,46 @@ class TaskAssignmentServiceUpdateStatusTest {
     verify(historyServiceMock, times(1)).recordStatusChange(a);
   }
 
-  // 히스토리 upsert - 신규 생성
+  //업서트 경로 검증: recordStatusChange 가 upsertHistory 를 정확히 호출하는지
   @Test
-  void recordStatusChange_creates_whenNotExists() {
+  void recordStatusChange_callsUpsert_withCorrectParams() {
     LocalDate d = LocalDate.of(2025, 8, 29);
     TaskAssignment a = ta(1L, 10L, 1L, 111L, d);
     a.setStatus(AssignmentStatus.COMPLETED);
 
-    when(historyRepo.findByAssignmentIdAndDate(1L, d)).thenReturn(Optional.empty());
-
     historyReal.recordStatusChange(a);
 
-    verify(historyRepo).save(argThat(h ->
-        h.getId() == null
-            && h.getAssignmentId().equals(1L)
-            && h.getDate().equals(d)
-            && h.getGroupMemberId().equals(111L)
-            && "청소".equals(h.getCategory())
-            && h.getStatus() == AssignmentStatus.COMPLETED
-    ));
+    verify(historyRepo, times(1)).upsertHistory(
+        eq(1L),                 // assignmentId
+        eq(111L),               // groupMemberId
+        eq("청소"),             // category
+        eq("COMPLETED"),        // status name()
+        argThat(sqlDate -> sqlDate.toLocalDate().equals(d)) // date
+    );
+    verifyNoMoreInteractions(historyRepo);
   }
 
-  // 히스토리 upsert - 업데이트
+  // (선택) 여러 건 생성 시, 각 건마다 업서트 호출되는지 검증
   @Test
-  void recordStatusChange_updates_whenExists() {
-    LocalDate d = LocalDate.of(2025, 8, 29);
-    TaskAssignment a = ta(1L, 10L, 1L, 222L, d);
-    a.setStatus(AssignmentStatus.SKIPPED);
+  void recordCreatedAssignments_callsUpsert_forEachAssignment() {
+    LocalDate d1 = LocalDate.of(2025, 8, 30);
+    LocalDate d2 = LocalDate.of(2025, 8, 31);
 
-    TaskAssignmentHistory existing = new TaskAssignmentHistory();
-    ReflectionTestUtils.setField(existing, "id", 999L);
-    existing.setAssignmentId(1L);
-    existing.setDate(d);
+    TaskAssignment a1 = ta(1L, 10L, 1L, 111L, d1);
+    a1.setStatus(AssignmentStatus.PENDING);
+    TaskAssignment a2 = ta(2L, 10L, 1L, 222L, d2);
+    a2.setStatus(AssignmentStatus.PENDING);
 
-    when(historyRepo.findByAssignmentIdAndDate(1L, d)).thenReturn(Optional.of(existing));
+    historyReal.recordCreatedAssignments(List.of(a1, a2));
 
-    historyReal.recordStatusChange(a);
-
-    verify(historyRepo).save(argThat(h ->
-        h.getId().equals(999L) // 같은 row 업데이트
-            && h.getAssignmentId().equals(1L)
-            && h.getDate().equals(d)
-            && h.getGroupMemberId().equals(222L)
-            && "청소".equals(h.getCategory())
-            && h.getStatus() == AssignmentStatus.SKIPPED
-    ));
+    verify(historyRepo, times(1)).upsertHistory(
+        eq(1L), eq(111L), eq("청소"), eq("PENDING"),
+        argThat(sqlDate -> sqlDate.toLocalDate().equals(d1))
+    );
+    verify(historyRepo, times(1)).upsertHistory(
+        eq(2L), eq(222L), eq("청소"), eq("PENDING"),
+        argThat(sqlDate -> sqlDate.toLocalDate().equals(d2))
+    );
+    verifyNoMoreInteractions(historyRepo);
   }
 }


### PR DESCRIPTION
## Changes
<!-- 이번 코드에서 가장 핵심적인 변경 사항을 한 줄로 요약 -->
주에 업무 2개이상 배정된 템플릿 삭제 불가 500 에러
<!-- 예: "회원가입 시 이메일 인증 기능 추가" -->

---

## Description
<!-- 변경된 기능에 대한 상세 설명 -->
   - 기존에 find -> save 분기라 동시 insert 경합으로 인한 UNIQUE키 경합으로 500오류 발생
<!-- 어떤 클래스/메서드가 수정되었는지, 어떤 로직이 추가/변경되었는지, 동작 흐름/UI 변경 여부 등 -->

---

## Context
<!-- 변경이 발생한 배경/상황 -->
  - FE요청
<!-- 예: 기획 요청, 사용자 피드백, 버그 리포트 내용, 요구사항 문서 등 -->

---

## Reason (선택한 구현 방법의 이유와 트레이드오프)
<!-- 왜 이 구현 방법을 선택했는지, 다른 방법과 비교한 장단점(트레이드오프) -->
   - 트렌젝션 사용으로 동시성 확보
<!-- 예: 성능, 유지보수성, 코드 단순성, 팀 기술 스택 호환성 등 고려 요소 -->

---

## Work Done
<!-- 구체적인 작업 내역 -->
- [변경 1]
- [변경 2]
- [변경 3]

---

## Test Plan
<!-- 어떤 테스트를 진행했고 결과가 어땠는지 -->
<!-- 예: Postman으로 API 호출 테스트 완료, JUnit 테스트 전부 성공 -->

---

## Notes
<!-- 리뷰어가 꼭 알아야 할 특이사항이나 주의사항 -->
<!-- 예: 다음 단계에서 구현 예정 / 임시 API 응답 구조 사용 중 -->

---

## Issue
<!-- 연결된 이슈가 있다면 작성 -->
  Closes #250 
<!-- ex: Closes #123 -->
